### PR TITLE
fix command line for linkchecker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,8 @@ jobs:
         # for excluded URLs, the checker seems to be stricter than Chrome
         args: >-
           --verbose --timeout 40 --insecure 
-          --exclude "https://www.msg.chem.iastate.edu/" 
-          --exclude "https://openmopac.net/"
-          codes.md
+          --exclude "https://www.msg.chem.iastate.edu/" "https://openmopac.net/"
+          -- codes.md
 
     - name: Fail if there were link errors
       run: exit ${{ steps.lc.outputs.exit_code }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Link Checker
       id: lc
-      uses: lycheeverse/lychee-action@v1.0.6
+      uses: lycheeverse/lychee-action@v1.0.8
       with:
         # See cli args at https://github.com/lycheeverse/lychee#commandline-parameters
         # for excluded URLs, the checker seems to be stricter than Chrome


### PR DESCRIPTION
When using options that can take multiple arguments (`--exclude`), the
input file needs to be prefixed with `--`.
See https://github.com/lycheeverse/lychee/issues/113