### PR TITLE
remove ASE/ASAP

### DIFF
--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -15,10 +15,6 @@
         "citations": 674,
         "datestamp": "2021-04-10"
       },
-      "ASE/ASAP": {
-        "citations": 836,
-        "datestamp": "2021-04-10"
-      },
       "ASW program package": {
         "citations": 0,
         "datestamp": "2021-04-10"
@@ -419,10 +415,6 @@
       },
       "Amber": {
         "citations": 1950,
-        "datestamp": "2021-01-04"
-      },
-      "ASE/ASAP": {
-        "citations": 846,
         "datestamp": "2021-01-04"
       },
       "GROMOS": {
@@ -835,10 +827,6 @@
         "citations": 1790,
         "datestamp": "2021-01-04"
       },
-      "ASE/ASAP": {
-        "citations": 746,
-        "datestamp": "2021-01-04"
-      },
       "GROMOS": {
         "citations": 1460,
         "datestamp": "2021-01-04"
@@ -1247,10 +1235,6 @@
       },
       "Amber": {
         "citations": 1590,
-        "datestamp": "2021-01-07"
-      },
-      "ASE/ASAP": {
-        "citations": 795,
         "datestamp": "2021-01-07"
       },
       "GROMOS": {
@@ -1663,10 +1647,6 @@
         "citations": 1560,
         "datestamp": "2021-01-07"
       },
-      "ASE/ASAP": {
-        "citations": 743,
-        "datestamp": "2021-01-07"
-      },
       "GROMOS": {
         "citations": 1390,
         "datestamp": "2021-01-07"
@@ -2077,10 +2057,6 @@
         "citations": 1510,
         "datestamp": "2021-01-07"
       },
-      "ASE/ASAP": {
-        "citations": 665,
-        "datestamp": "2021-01-07"
-      },
       "GROMOS": {
         "citations": 1260,
         "datestamp": "2021-01-07"
@@ -2485,10 +2461,6 @@
       },
       "ADF": {
         "citations": 518,
-        "datestamp": "2021-01-17"
-      },
-      "ASE/ASAP": {
-        "citations": 671,
         "datestamp": "2021-01-17"
       },
       "Amber": {
@@ -2901,10 +2873,6 @@
         "citations": 545,
         "datestamp": "2021-01-17"
       },
-      "ASE/ASAP": {
-        "citations": 653,
-        "datestamp": "2021-01-17"
-      },
       "Amber": {
         "citations": 1420,
         "datestamp": "2021-01-17"
@@ -3313,10 +3281,6 @@
       },
       "ADF": {
         "citations": 500,
-        "datestamp": "2021-01-17"
-      },
-      "ASE/ASAP": {
-        "citations": 637,
         "datestamp": "2021-01-17"
       },
       "Amber": {
@@ -3729,10 +3693,6 @@
         "citations": 440,
         "datestamp": "2021-01-17"
       },
-      "ASE/ASAP": {
-        "citations": 490,
-        "datestamp": "2021-01-17"
-      },
       "Amber": {
         "citations": 1230,
         "datestamp": "2021-01-17"
@@ -4141,10 +4101,6 @@
       },
       "ADF": {
         "citations": 451,
-        "datestamp": "2021-04-10"
-      },
-      "ASE/ASAP": {
-        "citations": 450,
         "datestamp": "2021-04-10"
       },
       "ASW program package": {

--- a/src/data/codes.json
+++ b/src/data/codes.json
@@ -41,23 +41,6 @@
     ],
     "nomad_tags": []
   },
-  "ASE/ASAP": {
-    "author_name": "Jacobsen",
-    "homepage": "https://wiki.fysik.dtu.dk/ase/index.html",
-    "license": "OS(CL)",
-    "license_annotation": null,
-    "name": "ASE/ASAP",
-    "query_method": "search term",
-    "query_string": "ASE Jacobsen",
-    "tags": [],
-    "types": [
-      "FF"
-    ],
-    "nomad_tags": [
-      "PI_member",
-      "data_collaboration"
-    ]
-  },
   "Amber": {
     "author_name": "Kollman",
     "homepage": "https://ambermd.org/",


### PR DESCRIPTION
ASAP is a standalone code hosted at https://wiki.fysik.dtu.dk/asap,
usually cited by providing this URL (and with <10 citations in 2020).

ASE is a python framework that can be used to run calculations with ASAP
but also with many others and does not qualify as an atomistic
simulation engine by itself.
The atomistic.software list may be extended to include workflow managers
like ASE going forward. In that case, however, we will make sure to
include all relevant ones.