### PR TITLE
add benchmarks column

### DIFF
--- a/src/components/Columns.js
+++ b/src/components/Columns.js
@@ -80,7 +80,20 @@ function getColumns(data, year) {
         },
       },
     },
+    {
+      name: "benchmarks",
+      label: "Benchmarks",
+      options: {
+        filter: true,
+        sort: true,
+        selected: false,
+        customBodyRenderLite: (dataIndex) => {
+          const types = data[dataIndex]["benchmarks"];
+          return types.map((x) => <a href={'https://molmod.ugent.be/deltacodesdft'} target="_blank" rel="noreferrer">{x}</a>);
+        },
+      },
 
+    },
     {
       name: "tags",
       label: "Tags",

--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -291,7 +291,7 @@
         "citations": 48,
         "datestamp": "2021-04-10"
       },
-      "octopus": {
+      "Octopus": {
         "citations": 294,
         "datestamp": "2021-04-10"
       },
@@ -517,7 +517,7 @@
         "citations": 190,
         "datestamp": "2021-01-04"
       },
-      "octopus": {
+      "Octopus": {
         "citations": 248,
         "datestamp": "2021-01-04"
       },
@@ -923,7 +923,7 @@
         "citations": 216,
         "datestamp": "2021-01-04"
       },
-      "octopus": {
+      "Octopus": {
         "citations": 236,
         "datestamp": "2021-01-04"
       },
@@ -1329,7 +1329,7 @@
         "citations": 213,
         "datestamp": "2021-01-07"
       },
-      "octopus": {
+      "Octopus": {
         "citations": 214,
         "datestamp": "2021-01-07"
       },
@@ -1735,7 +1735,7 @@
         "citations": 244,
         "datestamp": "2021-01-07"
       },
-      "octopus": {
+      "Octopus": {
         "citations": 178,
         "datestamp": "2021-01-07"
       },
@@ -2141,7 +2141,7 @@
         "citations": 246,
         "datestamp": "2021-01-07"
       },
-      "octopus": {
+      "Octopus": {
         "citations": 200,
         "datestamp": "2021-01-07"
       },
@@ -2719,7 +2719,7 @@
         "citations": 13,
         "datestamp": "2021-01-17"
       },
-      "octopus": {
+      "Octopus": {
         "citations": 160,
         "datestamp": "2021-01-17"
       },
@@ -3125,7 +3125,7 @@
         "citations": 7,
         "datestamp": "2021-01-17"
       },
-      "octopus": {
+      "Octopus": {
         "citations": 165,
         "datestamp": "2021-01-17"
       },
@@ -3531,7 +3531,7 @@
         "citations": 6,
         "datestamp": "2021-01-17"
       },
-      "octopus": {
+      "Octopus": {
         "citations": 156,
         "datestamp": "2021-01-17"
       },
@@ -3937,7 +3937,7 @@
         "citations": 0,
         "datestamp": "2021-01-17"
       },
-      "octopus": {
+      "Octopus": {
         "citations": 141,
         "datestamp": "2021-01-17"
       },
@@ -4347,7 +4347,7 @@
         "citations": 0,
         "datestamp": "2021-04-10"
       },
-      "octopus": {
+      "Octopus": {
         "citations": 110,
         "datestamp": "2021-04-10"
       },

--- a/src/data/codes.json
+++ b/src/data/codes.json
@@ -1,10 +1,17 @@
 {
   "ABINIT": {
     "author_name": "Gonze",
+    "benchmarks": [
+      "Δ-value"
+    ],
     "homepage": "https://www.abinit.org/",
     "license": "OS(CL)",
     "license_annotation": "GPL-3.0",
     "name": "ABINIT",
+    "nomad_tags": [
+      "PI_member",
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "ABINIT Gonze",
     "tags": [
@@ -16,18 +23,16 @@
     "types": [
       "DFT",
       "WFM"
-    ],
-    "nomad_tags": [
-      "PI_member",
-      "data_collaboration"
     ]
   },
   "ADF": {
     "author_name": "Baerends",
+    "benchmarks": [],
     "homepage": "https://www.scm.com/product/adf/",
     "license": "C(S)",
     "license_annotation": null,
     "name": "ADF",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "ADF Baerends",
     "tags": [
@@ -38,31 +43,22 @@
     "types": [
       "DFT",
       "WFM"
-    ],
-    "nomad_tags": []
-  },
-  "Amber": {
-    "author_name": "Kollman",
-    "homepage": "https://ambermd.org/",
-    "license": "C(S)",
-    "license_annotation": null,
-    "name": "Amber",
-    "query_method": "search term",
-    "query_string": "Amber program Kollman",
-    "tags": [],
-    "types": [
-      "FF"
-    ],
-    "nomad_tags": [
-      "PI_member"
     ]
   },
   "ATK/QuantumATK": {
     "author_name": "QuantumWise",
+    "benchmarks": [
+      "Δ-value"
+    ],
     "homepage": "https://quantumwise.com/",
     "license": "C(C)",
     "license_annotation": null,
     "name": "ATK/QuantumATK",
+    "nomad_tags": [
+      "PI_member",
+      "data_collaboration"
+    ],
+    "notes": "See VASP, ABINIT, FHI-aims, Quantum ESPRESSO",
     "query_method": "search term",
     "query_string": "\"Atomistix ToolKit\" OR QuantumATK",
     "tags": [
@@ -72,33 +68,50 @@
       "DFT",
       "TB",
       "FF"
-    ],
-    "notes": "See VASP, ABINIT, FHI-aims, Quantum ESPRESSO",
+    ]
+  },
+  "Amber": {
+    "author_name": "Kollman",
+    "benchmarks": [],
+    "homepage": "https://ambermd.org/",
+    "license": "C(S)",
+    "license_annotation": null,
+    "name": "Amber",
     "nomad_tags": [
-      "PI_member",
-      "data_collaboration"
+      "PI_member"
+    ],
+    "query_method": "search term",
+    "query_string": "Amber program Kollman",
+    "tags": [],
+    "types": [
+      "FF"
     ]
   },
   "BOSS": {
     "author_name": "Jorgensen",
+    "benchmarks": [],
     "homepage": "http://zarbi.chem.yale.edu/software.html#boss",
     "license": "F(A)",
     "license_annotation": null,
     "name": "BOSS",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "BOSS program Jorgensen",
     "tags": [],
     "types": [
       "FF"
-    ],
-    "nomad_tags": []
+    ]
   },
   "CASINO": {
     "author_name": "Needs and L\u00f3pez R\u00edos",
+    "benchmarks": [],
     "homepage": "https://vallico.net/casinoqmc/",
     "license": "F(A)",
     "license_annotation": null,
     "name": "CASINO",
+    "nomad_tags": [
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "\"CASINO\" \"Needs\" Rios",
     "tags": [
@@ -111,17 +124,21 @@
     ],
     "types": [
       "QMC"
-    ],
-    "nomad_tags": [
-      "data_collaboration"
     ]
   },
   "CASTEP": {
     "author_name": "Payne",
+    "benchmarks": [
+      "Δ-value"
+    ],
     "homepage": "http://www.castep.org",
     "license": "F(A)",
     "license_annotation": "Free for academic use in UK",
     "name": "CASTEP",
+    "nomad_tags": [
+      "PI_member",
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "\"CASTEP\" \"Payne\" OR \"Materials Studio\" OR \"Material Studio\"",
     "tags": [
@@ -133,18 +150,16 @@
     "types": [
       "DFT",
       "WFM"
-    ],
-    "nomad_tags": [
-      "PI_member",
-      "data_collaboration"
     ]
   },
   "CFOUR": {
     "author_name": "Stanton",
+    "benchmarks": [],
     "homepage": "http://www.cfour.de/",
     "license": "F(A)",
     "license_annotation": "Custom license agreement",
     "name": "CFOUR",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "\"CFOUR\" Stanton",
     "tags": [
@@ -154,29 +169,33 @@
     ],
     "types": [
       "WFM"
-    ],
-    "nomad_tags": []
+    ]
   },
   "CHARMM": {
     "author_name": "Karplus",
+    "benchmarks": [],
     "homepage": "https://www.charmm.org/",
     "license": "C(S)",
     "license_annotation": null,
     "name": "CHARMM",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "CHARMM program Karplus",
     "tags": [],
     "types": [
       "FF"
-    ],
-    "nomad_tags": []
+    ]
   },
   "CP2K": {
     "author_name": "Hutter",
+    "benchmarks": [],
     "homepage": "https://www.cp2k.org/",
     "license": "OS(CL)",
     "license_annotation": "GPL-2.0",
     "name": "CP2K",
+    "nomad_tags": [
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "\"CP2K\" \"Hutter\" OR \"www.cp2k.org\"",
     "tags": [
@@ -189,17 +208,19 @@
     "types": [
       "DFT",
       "WFM"
-    ],
-    "nomad_tags": [
-      "data_collaboration"
     ]
   },
   "CPMD": {
     "author_name": "Hutter",
+    "benchmarks": [],
     "homepage": "https://www.cpmd.org/",
     "license": "F(A)",
     "license_annotation": "Early Release Software Program License Agreement For CPMD",
     "name": "CPMD",
+    "nomad_tags": [
+      "PI_member",
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "CPMD Hutter",
     "tags": [
@@ -209,18 +230,18 @@
     ],
     "types": [
       "DFT"
-    ],
-    "nomad_tags": [
-      "PI_member",
-      "data_collaboration"
     ]
   },
   "CRYSTAL": {
     "author_name": "Dovesi",
+    "benchmarks": [],
     "homepage": "https://www.crystal.unito.it/index.php",
     "license": "C(C)",
     "license_annotation": "Free demo limited to 10 atoms per primitive cell.",
     "name": "CRYSTAL",
+    "nomad_tags": [
+      "PI_member"
+    ],
     "query_method": "search term",
     "query_string": "\"CRYSTAL code\" OR \"CRYSTAL17\" OR \"CRYSTAL14\" OR \"CRYSTAL09\" OR \"CRYSTAL06\" Dovesi",
     "tags": [
@@ -232,34 +253,34 @@
     "types": [
       "DFT",
       "WFM"
-    ],
-    "nomad_tags": [
-      "PI_member"
     ]
   },
   "DFTB+": {
     "author_name": "Aradi",
+    "benchmarks": [],
     "homepage": "https://www.dftb-plus.info",
     "license": "OS(CL)",
     "license_annotation": "LGPL-3.0-or-later",
     "name": "DFTB+",
+    "nomad_tags": [
+      "data_collaboration"
+    ],
     "query_method": "publication",
-    "query_string": "B. Aradi, B. Hourahine, and Th. Frauenheim. JPC A 2007 111 (26), 5678-5684",
     "query_publication_id": "11397957054615082073",
+    "query_string": "B. Aradi, B. Hourahine, and Th. Frauenheim. JPC A 2007 111 (26), 5678-5684",
     "tags": [],
     "types": [
       "TB"
-    ],
-    "nomad_tags": [
-      "data_collaboration"
     ]
   },
   "DIRAC": {
     "author_name": "Saue",
+    "benchmarks": [],
     "homepage": "http://www.diracprogram.org/doku.php",
     "license": "F",
     "license_annotation": "Custom license",
     "name": "DIRAC",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "DIRAC \"Saue\"",
     "tags": [
@@ -269,29 +290,34 @@
     "types": [
       "DFT",
       "WFM"
-    ],
-    "nomad_tags": []
+    ]
   },
   "DL_POLY": {
     "author_name": "Smith",
+    "benchmarks": [],
     "homepage": "https://www.scd.stfc.ac.uk/Pages/DL_POLY.aspx",
     "license": "F(A)",
     "license_annotation": "DL_POLY_4 licence agreement",
     "name": "DL_POLY",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "\"DL_POLY\" Smith",
     "tags": [],
     "types": [
       "FF"
-    ],
-    "nomad_tags": []
+    ]
   },
   "DMol3": {
     "author_name": "Delley",
+    "benchmarks": [],
     "homepage": "https://www.3dsbiovia.com/products/datasheets/dmol3.pdf",
     "license": "C(C)",
     "license_annotation": null,
     "name": "DMol3",
+    "nomad_tags": [
+      "PI_member",
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "DMol3 OR \"DMol^3\" Delley",
     "tags": [
@@ -302,18 +328,16 @@
     ],
     "types": [
       "DFT"
-    ],
-    "nomad_tags": [
-      "PI_member",
-      "data_collaboration"
     ]
   },
   "Dalton": {
     "author_name": "\u00c5gren",
+    "benchmarks": [],
     "homepage": "https://daltonprogram.org/",
     "license": "OS(CL)",
     "license_annotation": "LGPL-2.1",
     "name": "Dalton",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "Dalton \u00c5gren",
     "tags": [
@@ -322,31 +346,91 @@
     ],
     "types": [
       "WFM"
-    ],
-    "nomad_tags": []
+    ]
+  },
+  "Desmond": {
+    "author_name": "Schr\u00f6dinger",
+    "benchmarks": [],
+    "homepage": "https://www.schrodinger.com/products/desmond",
+    "license": "F(A)",
+    "license_annotation": "",
+    "name": "Desmond",
+    "nomad_tags": [],
+    "query_method": "search term",
+    "query_string": "desmond schr\u00f6dinger",
+    "tags": [],
+    "types": [
+      "FF"
+    ]
   },
   "Discovery Studio": {
     "author_name": "Accelrys",
+    "benchmarks": [],
     "homepage": "https://en.wikipedia.org/wiki/Discovery_Studio",
     "license": "C(C)",
     "license_annotation": null,
     "name": "Discovery Studio",
+    "nomad_tags": [],
+    "notes": "See CHARMM for FF and DMol3 for DFT",
     "query_method": "search term",
     "query_string": "\"Discovery Studio\" Accelrys",
     "tags": [],
     "types": [
       "FF",
       "DFT"
+    ]
+  },
+  "EPW": {
+    "author_name": "Giustino",
+    "benchmarks": [],
+    "homepage": "https://epw-code.org",
+    "license": "OS(CL)",
+    "license_annotation": "GPL-2.0",
+    "name": "EPW",
+    "nomad_tags": [
+      "PI_member",
+      "data_collaboration"
     ],
-    "notes": "See CHARMM for FF and DMol3 for DFT",
-    "nomad_tags": []
+    "query_method": "search term",
+    "query_string": "\"EPW\" Giustino",
+    "tags": [
+      "PBC",
+      "PP",
+      "PW"
+    ],
+    "types": [
+      "S"
+    ]
+  },
+  "ESPResSo": {
+    "author_name": "Holm",
+    "benchmarks": [],
+    "homepage": "https://espressomd.org/",
+    "license": "OS(CL)",
+    "license_annotation": "GPL-3.0",
+    "name": "ESPResSo",
+    "nomad_tags": [
+      "data_collaboration"
+    ],
+    "query_method": "search term",
+    "query_string": "\"molecular dynamics\" OR \"soft matter\" espresso holm",
+    "tags": [],
+    "types": [
+      "FF"
+    ]
   },
   "Elk": {
     "author_name": "Dewhurst",
+    "benchmarks": [
+      "Δ-value"
+    ],
     "homepage": "http://elk.sourceforge.net/",
     "license": "OS(CL)",
     "license_annotation": "GPL-3.0-or-later",
     "name": "Elk",
+    "nomad_tags": [
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "\"elk.sourceforge.net\"",
     "tags": [
@@ -357,70 +441,38 @@
     "types": [
       "DFT",
       "WFM"
-    ],
-    "nomad_tags": [
-      "data_collaboration"
-    ]
-  },
-  "EPW": {
-    "author_name": "Giustino",
-    "homepage": "https://epw-code.org",
-    "license": "OS(CL)",
-    "license_annotation": "GPL-2.0",
-    "name": "EPW",
-    "query_method": "search term",
-    "query_string": "\"EPW\" Giustino",
-    "tags": [
-      "PBC",
-      "PP",
-      "PW"
-    ],
-    "types": [
-      "S"
-    ],
-    "nomad_tags": [
-      "PI_member",
-      "data_collaboration"
-    ]
-  },
-  "ESPResSo": {
-    "author_name": "Holm",
-    "homepage": "https://espressomd.org/",
-    "license": "OS(CL)",
-    "license_annotation": "GPL-3.0",
-    "name": "ESPResSo",
-    "query_method": "search term",
-    "query_string": "\"molecular dynamics\" OR \"soft matter\" espresso holm",
-    "tags": [],
-    "types": [
-      "FF"
-    ],
-    "nomad_tags": [
-      "data_collaboration"
     ]
   },
   "FEFF": {
     "author_name": "Rehr",
+    "benchmarks": [],
     "homepage": "https://github.com/times-software/feff10",
     "license": "F",
     "license_annotation": "FEFF10 license",
     "name": "FEFF",
+    "nomad_tags": [
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "\"FEFF\" Rehr",
     "tags": [],
     "types": [
       "S"
-    ],
-    "nomad_tags": [
-      "data_collaboration"
     ]
   },
   "FHI-aims": {
     "author_name": "Blum",
+    "benchmarks": [
+      "Δ-value"
+    ],
     "homepage": "http://www.fhi-berlin.mpg.de/aims/",
     "license": "C(S)",
     "license_annotation": null,
     "name": "FHI-aims",
+    "nomad_tags": [
+      "PI_member",
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "FHI-aims Blum",
     "tags": [
@@ -431,18 +483,20 @@
     "types": [
       "DFT",
       "WFM"
-    ],
-    "nomad_tags": [
-      "PI_member",
-      "data_collaboration"
     ]
   },
   "FPLO": {
     "author_name": "Koepernik",
+    "benchmarks": [
+      "Δ-value"
+    ],
     "homepage": "https://www.fplo.de/",
     "license": "C(S)",
     "license_annotation": null,
     "name": "FPLO",
+    "nomad_tags": [
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "FPLO Koepernik",
     "tags": [
@@ -452,31 +506,53 @@
     ],
     "types": [
       "DFT"
+    ]
+  },
+  "Firefly": {
+    "author_name": "Granovsky",
+    "benchmarks": [],
+    "homepage": "http://classic.chem.msu.su/gran/gamess/index.html",
+    "license": "F",
+    "license_annotation": "Firefly Quantum Chemistry Package License Agreement",
+    "name": "Firefly",
+    "nomad_tags": [],
+    "query_method": "search term",
+    "query_string": "firefly \"Granovsky\"",
+    "tags": [
+      "AE",
+      "GTO",
+      "PP"
     ],
-    "nomad_tags": [
-      "data_collaboration"
+    "types": [
+      "WFM",
+      "DFT"
     ]
   },
   "FoldX": {
     "author_name": "Serrano",
+    "benchmarks": [],
     "homepage": "http://foldx.crg.es/",
     "license": "F(A)",
     "license_annotation": "2-week evaluation license also available",
     "name": "FoldX",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "FoldX Serrano",
     "tags": [],
     "types": [
       "FF"
-    ],
-    "nomad_tags": []
+    ]
   },
   "GAMESS": {
     "author_name": "Gordon",
+    "benchmarks": [],
     "homepage": "https://www.msg.chem.iastate.edu/",
     "license": "F",
     "license_annotation": "Registration required for academic and industrial users.",
     "name": "GAMESS",
+    "nomad_tags": [
+      "PI_member"
+    ],
     "query_method": "search term",
     "query_string": "GAMESS Gordon",
     "tags": [
@@ -487,17 +563,20 @@
     "types": [
       "WFM",
       "DFT"
-    ],
-    "nomad_tags": [
-      "PI_member"
     ]
   },
   "GPAW": {
     "author_name": "Mortensen",
+    "benchmarks": [
+      "Δ-value"
+    ],
     "homepage": "https://wiki.fysik.dtu.dk/gpaw/",
     "license": "OS(CL)",
     "license_annotation": "GPL-3.0",
     "name": "GPAW",
+    "nomad_tags": [
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "GPAW Mortensen",
     "tags": [
@@ -510,45 +589,48 @@
     ],
     "types": [
       "DFT"
-    ],
-    "nomad_tags": [
-      "data_collaboration"
     ]
   },
   "GROMOS": {
     "author_name": "Van Gunsteren",
+    "benchmarks": [],
     "homepage": "http://www.gromos.net/",
     "license": "C(S)",
     "license_annotation": null,
     "name": "GROMOS",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "GROMOS van Gunsteren",
     "tags": [],
     "types": [
       "FF"
-    ],
-    "nomad_tags": []
+    ]
   },
   "GULP": {
     "author_name": "Gale",
+    "benchmarks": [],
     "homepage": "https://gulp.curtin.edu.au/gulp/",
     "license": "F(A)",
     "license_annotation": null,
     "name": "GULP",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "GULP Gale",
     "tags": [],
     "types": [
       "FF"
-    ],
-    "nomad_tags": []
+    ]
   },
   "Gaussian": {
     "author_name": "Frisch",
+    "benchmarks": [],
     "homepage": "https://www.gaussian.com/",
     "license": "C(S)",
     "license_annotation": null,
     "name": "Gaussian",
+    "nomad_tags": [
+      "PI_member"
+    ],
     "query_method": "search term",
     "query_string": "Frisch \"Gaussian 70\" OR \"Gaussian 76\" OR \"Gaussian 80\" OR \"Gaussian 82\" OR \"Gaussian 86\" OR \"Gaussian 88\" OR \"Gaussian 90\" OR \"Gaussian 92\" OR \"Gaussian 94\" OR \"Gaussian 98\" OR \"Gaussian 03\" OR \"Gaussian 09\" OR \"Gaussian 16\"",
     "tags": [
@@ -560,47 +642,68 @@
     "types": [
       "WFM",
       "DFT"
-    ],
-    "nomad_tags": [
-      "PI_member"
     ]
   },
   "Gromacs": {
     "author_name": "Lindahl",
+    "benchmarks": [],
     "homepage": "https://www.gromacs.org/",
     "license": "OS(CL)",
     "license_annotation": "LGPL-2.1-or-later",
     "name": "Gromacs",
+    "nomad_tags": [
+      "PI_member"
+    ],
     "query_method": "search term",
     "query_string": "\"GROMACS\" Lindahl OR Berendsen",
     "tags": [],
     "types": [
       "FF"
-    ],
-    "nomad_tags": [
-      "PI_member"
     ]
   },
   "HOOMD-blue": {
     "author_name": "Anderson",
+    "benchmarks": [],
     "homepage": "https://codeblue.umich.edu/hoomd-blue/index.html",
     "license": "OS(CL)",
     "license_annotation": "BSD-3-Clause",
     "name": "HOOMD-blue",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "HOOMD-blue Anderson",
     "tags": [],
     "types": [
       "FF"
+    ]
+  },
+  "Hyperchem": {
+    "author_name": "Hypercube",
+    "benchmarks": [],
+    "homepage": "http://www.hyper.com/?tabid=360",
+    "license": "C(C)",
+    "license_annotation": "",
+    "name": "Hyperchem",
+    "nomad_tags": [],
+    "query_method": "search term",
+    "query_string": "hyperchem hypercube",
+    "tags": [
+      "GTO",
+      "PP"
     ],
-    "nomad_tags": []
+    "types": [
+      "FF",
+      "WFM",
+      "DFT"
+    ]
   },
   "Jaguar": {
     "author_name": "Schr\u00f6dinger",
+    "benchmarks": [],
     "homepage": "https://www.schrodinger.com/Jaguar/",
     "license": "C(C)",
     "license_annotation": null,
     "name": "Jaguar",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "Jaguar Schr\u00f6dinger",
     "tags": [
@@ -612,47 +715,50 @@
     "types": [
       "DFT",
       "WFM"
-    ],
-    "nomad_tags": []
+    ]
   },
   "LAMMPS": {
     "author_name": "Plimpton",
+    "benchmarks": [],
     "homepage": "https://lammps.sandia.gov/",
     "license": "OS(CL)",
     "license_annotation": "GPL-2.0",
     "name": "LAMMPS",
+    "nomad_tags": [
+      "PI_member"
+    ],
     "query_method": "search term",
     "query_string": "LAMMPS Plimpton",
     "tags": [],
     "types": [
       "FF"
-    ],
-    "nomad_tags": [
-      "PI_member"
     ]
   },
   "MOE": {
     "author_name": "Chemical Computing Group",
+    "benchmarks": [],
     "homepage": "https://www.chemcomp.com/",
     "license": "C(C)",
     "license_annotation": null,
     "name": "MOE",
+    "nomad_tags": [],
+    "notes": "See Gaussian, ADF, MOPAC, GAMESS for WFM",
     "query_method": "search term",
     "query_string": "MOE \"Chemical Computing Group\"",
     "tags": [],
     "types": [
       "FF",
       "WFM"
-    ],
-    "notes": "See Gaussian, ADF, MOPAC, GAMESS for WFM",
-    "nomad_tags": []
+    ]
   },
   "MOLCAS": {
     "author_name": "Lindh",
+    "benchmarks": [],
     "homepage": "http://www.molcas.org/",
     "license": "C(S)",
     "license_annotation": null,
     "name": "MOLCAS",
+    "nomad_tags": [],
     "notes": "See OpenMolcas for open-source core.",
     "query_method": "search term",
     "query_string": "MOLCAS Lindh",
@@ -664,34 +770,16 @@
     "types": [
       "WFM",
       "DFT"
-    ],
-    "nomad_tags": []
-  },
-  "OpenMolcas": {
-    "author_name": "Lindh",
-    "homepage": "https://molcas.gitlab.io/OpenMolcas/sphinx/",
-    "license": "OS(CL)",
-    "license_annotation": "LGPL-2.1",
-    "name": "OpenMolcas",
-    "query_method": "search term",
-    "query_string": "\"Openmolcas\" Lindh",
-    "tags": [
-      "AE",
-      "GTO",
-      "PP"
-    ],
-    "types": [
-      "WFM",
-      "DFT"
-    ],
-    "nomad_tags": []
+    ]
   },
   "MOPAC": {
     "author_name": "Stewart",
+    "benchmarks": [],
     "homepage": "http://openmopac.net/",
     "license": "F(A)",
     "license_annotation": "",
     "name": "MOPAC",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "MOPAC Stewart",
     "tags": [
@@ -702,29 +790,31 @@
     "types": [
       "FF",
       "WFM"
-    ],
-    "nomad_tags": []
+    ]
   },
   "MacroModel": {
     "author_name": "Schr\u00f6dinger",
+    "benchmarks": [],
     "homepage": "https://www.schrodinger.com/MacroModel/",
     "license": "C(C)",
     "license_annotation": null,
     "name": "MacroModel",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "MacroModel Schr\u00f6dinger",
     "tags": [],
     "types": [
       "FF"
-    ],
-    "nomad_tags": []
+    ]
   },
   "Molpro": {
     "author_name": "Werner",
+    "benchmarks": [],
     "homepage": "https://www.molpro.net/",
     "license": "C(S)",
     "license_annotation": null,
     "name": "Molpro",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "Molpro Werner",
     "tags": [
@@ -735,31 +825,35 @@
     "types": [
       "DFT",
       "WFM"
-    ],
-    "nomad_tags": []
+    ]
   },
   "NAMD": {
     "author_name": "Schulten",
+    "benchmarks": [],
     "homepage": "https://www.ks.uiuc.edu/Research/namd/",
     "license": "F(A)",
     "license_annotation": null,
     "name": "NAMD",
+    "nomad_tags": [
+      "PI_member"
+    ],
     "query_method": "search term",
     "query_string": "\"NAMD\" Schulten",
     "tags": [],
     "types": [
       "FF"
-    ],
-    "nomad_tags": [
-      "PI_member"
     ]
   },
   "NWChem": {
     "author_name": "Valiev",
+    "benchmarks": [],
     "homepage": "https://nwchemgit.github.io/",
     "license": "OS(P)",
     "license_annotation": "ECL-2.0",
     "name": "NWChem",
+    "nomad_tags": [
+      "PI_member"
+    ],
     "query_method": "search term",
     "query_string": "NWChem Valiev",
     "tags": [
@@ -774,17 +868,19 @@
       "DFT",
       "WFM",
       "FF"
-    ],
-    "nomad_tags": [
-      "PI_member"
     ]
   },
   "ORCA": {
     "author_name": "Neese",
+    "benchmarks": [],
     "homepage": "https://orcaforum.kofo.mpg.de/app.php/portal",
     "license": "F(A)",
     "license_annotation": null,
     "name": "ORCA",
+    "nomad_tags": [
+      "PI_member",
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "ORCA Neese",
     "tags": [
@@ -795,18 +891,33 @@
     "types": [
       "WFM",
       "DFT"
-    ],
-    "nomad_tags": [
-      "PI_member",
-      "data_collaboration"
+    ]
+  },
+  "OpenMM": {
+    "author_name": "Eastman",
+    "benchmarks": [],
+    "homepage": "http://openmm.org",
+    "license": "OS(P)",
+    "license_annotation": "MIT",
+    "name": "OpenMM",
+    "nomad_tags": [],
+    "query_method": "search term",
+    "query_string": "openmm Eastman",
+    "tags": [],
+    "types": [
+      "FF"
     ]
   },
   "OpenMX": {
     "author_name": "Ozaki",
+    "benchmarks": [
+      "Δ-value"
+    ],
     "homepage": "http://www.openmx-square.org/",
     "license": "OS(CL)",
     "license_annotation": "GPL-3.0",
     "name": "OpenMX",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "OpenMX Ozaki",
     "tags": [
@@ -816,15 +927,36 @@
     ],
     "types": [
       "DFT"
+    ]
+  },
+  "OpenMolcas": {
+    "author_name": "Lindh",
+    "benchmarks": [],
+    "homepage": "https://molcas.gitlab.io/OpenMolcas/sphinx/",
+    "license": "OS(CL)",
+    "license_annotation": "LGPL-2.1",
+    "name": "OpenMolcas",
+    "nomad_tags": [],
+    "query_method": "search term",
+    "query_string": "\"Openmolcas\" Lindh",
+    "tags": [
+      "AE",
+      "GTO",
+      "PP"
     ],
-    "nomad_tags": []
+    "types": [
+      "WFM",
+      "DFT"
+    ]
   },
   "Psi4": {
     "author_name": "Sherrill",
+    "benchmarks": [],
     "homepage": "https://www.psicode.org/",
     "license": "OS(CL)",
     "license_annotation": "LGPL-3.0-only",
     "name": "Psi4",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "Psi4 Sherrill",
     "tags": [
@@ -834,15 +966,35 @@
     "types": [
       "WFM",
       "DFT"
+    ]
+  },
+  "PySCF": {
+    "author_name": "Chan",
+    "benchmarks": [],
+    "homepage": "https://pyscf.org/",
+    "license": "OS(P)",
+    "license_annotation": "Apache-2.0",
+    "name": "PySCF",
+    "nomad_tags": [],
+    "query_method": "search term",
+    "query_string": "pyscf \"chan\"",
+    "tags": [
+      "GTO",
+      "PP"
     ],
-    "nomad_tags": []
+    "types": [
+      "WFM",
+      "DFT"
+    ]
   },
   "Q-Chem": {
     "author_name": "Shao",
+    "benchmarks": [],
     "homepage": "https://www.q-chem.com/",
     "license": "C(S)",
     "license_annotation": null,
     "name": "Q-Chem",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "\"Q-Chem\" Shao",
     "tags": [
@@ -853,15 +1005,21 @@
     "types": [
       "WFM",
       "DFT"
-    ],
-    "nomad_tags": []
+    ]
   },
   "Quantum ESPRESSO": {
     "author_name": "Giannozzi",
+    "benchmarks": [
+      "Δ-value"
+    ],
     "homepage": "https://www.quantum-espresso.org/",
     "license": "OS(CL)",
     "license_annotation": "GPL-2.0",
     "name": "Quantum ESPRESSO",
+    "nomad_tags": [
+      "PI_member",
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "\"Quantum ESPRESSO\" Giannozzi",
     "tags": [
@@ -872,34 +1030,34 @@
     "types": [
       "DFT",
       "S"
-    ],
-    "nomad_tags": [
-      "PI_member",
-      "data_collaboration"
     ]
   },
   "RASPA": {
     "author_name": "Dubbeldam",
+    "benchmarks": [],
     "homepage": "https://github.com/iRASPA/RASPA2",
     "license": "OS(P)",
     "license_annotation": "MIT",
     "name": "RASPA",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "\"RASPA\" OR \"RASPA2\" Dubbeldam",
-    "tags": [
-    ],
+    "tags": [],
     "types": [
       "FF"
-    ],
-    "nomad_tags": [
     ]
   },
   "SIESTA": {
     "author_name": "Soler",
+    "benchmarks": [],
     "homepage": "https://departments.icmab.es/leem/siesta/",
     "license": "OS(CL)",
     "license_annotation": "GPL-3.0",
     "name": "SIESTA",
+    "nomad_tags": [
+      "PI_member",
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "SIESTA Soler",
     "tags": [
@@ -909,18 +1067,18 @@
     ],
     "types": [
       "DFT"
-    ],
-    "nomad_tags": [
-      "PI_member",
-      "data_collaboration"
     ]
   },
   "TB-LMTO-ASA": {
     "author_name": "Andersen",
+    "benchmarks": [],
     "homepage": "https://www2.fkf.mpg.de/andersen/LMTODOC/LMTODOC.html",
     "license": "F(A)",
     "license_annotation": null,
     "name": "TB-LMTO-ASA",
+    "nomad_tags": [
+      "PI_member"
+    ],
     "query_method": "search term",
     "query_string": "\"TB-LMTO-ASA\"",
     "tags": [
@@ -930,33 +1088,36 @@
     "types": [
       "DFT",
       "TB"
-    ],
-    "nomad_tags": [
-      "PI_member"
     ]
   },
   "TINKER": {
     "author_name": "Ponder",
+    "benchmarks": [],
     "homepage": "https://dasher.wustl.edu/tinker/",
     "license": "F(A)",
     "license_annotation": null,
     "name": "TINKER",
+    "nomad_tags": [
+      "PI_member"
+    ],
     "query_method": "search term",
     "query_string": "TINKER Ponder",
     "tags": [],
     "types": [
       "FF"
-    ],
-    "nomad_tags": [
-      "PI_member"
     ]
   },
   "TURBOMOLE": {
     "author_name": "Ahlrichs",
+    "benchmarks": [],
     "homepage": "https://www.turbomole.com/",
     "license": "C(S)",
     "license_annotation": null,
     "name": "TURBOMOLE",
+    "nomad_tags": [
+      "PI_member",
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "TURBOMOLE Ahlrichs",
     "tags": [
@@ -968,18 +1129,21 @@
     "types": [
       "WFM",
       "DFT"
-    ],
-    "nomad_tags": [
-      "PI_member",
-      "data_collaboration"
     ]
   },
   "VASP": {
     "author_name": "Kresse",
+    "benchmarks": [
+      "Δ-value"
+    ],
     "homepage": "https://www.vasp.at/",
     "license": "C(S)",
     "license_annotation": "Free for academic use in Austria",
     "name": "VASP",
+    "nomad_tags": [
+      "PI_member",
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "VASP Kresse",
     "tags": [
@@ -991,32 +1155,36 @@
     "types": [
       "DFT",
       "WFM"
-    ],
-    "nomad_tags": [
-      "PI_member",
-      "data_collaboration"
     ]
   },
   "WHAT IF": {
     "author_name": "Vriend",
+    "benchmarks": [],
     "homepage": "https://swift.cmbi.umcn.nl/whatif/",
     "license": "C(C)",
     "license_annotation": "Discontinued.",
     "name": "WHAT IF",
+    "nomad_tags": [],
     "query_method": "search term",
     "query_string": "\"WHAT IF\" \"Vriend\" molecular",
     "tags": [],
     "types": [
       "FF"
-    ],
-    "nomad_tags": []
+    ]
   },
   "WIEN2k": {
     "author_name": "Blaha",
+    "benchmarks": [
+      "Δ-value"
+    ],
     "homepage": "http://www.wien2k.at/",
     "license": "C(S)",
     "license_annotation": null,
     "name": "WIEN2k",
+    "nomad_tags": [
+      "PI_member",
+      "data_collaboration"
+    ],
     "query_method": "search term",
     "query_string": "WIEN2k Blaha",
     "tags": [
@@ -1027,186 +1195,11 @@
     "types": [
       "DFT",
       "WFM"
-    ],
-    "nomad_tags": [
-      "PI_member",
-      "data_collaboration"
     ]
-  },
-  "YASARA": {
-    "author_name": "Krieger",
-    "homepage": "http://yasara.org/",
-    "license": "C(C)",
-    "license_annotation": null,
-    "name": "YASARA",
-    "query_method": "search term",
-    "query_string": "YASARA Krieger",
-    "tags": [],
-    "types": [
-      "FF"
-    ],
-    "nomad_tags": []
-  },
-  "Yambo": {
-    "author_name": "Marini",
-    "homepage": "http://www.yambo-code.org/",
-    "license": "OS(CL)",
-    "license_annotation": "GPL-2.0",
-    "name": "Yambo",
-    "query_method": "search term",
-    "query_string": "Yambo Marini",
-    "tags": [
-      "PBC",
-      "PP",
-      "PW"
-    ],
-    "types": [
-      "S"
-    ],
-    "nomad_tags": []
-  },
-  "exciting": {
-    "author_name": "Draxl",
-    "homepage": "http://exciting-code.org/",
-    "license": "OS(CL)",
-    "license_annotation": "GPL-2.0-or-later",
-    "name": "exciting",
-    "query_method": "search term",
-    "query_string": "\"exciting\" code Draxl",
-    "tags": [
-      "PBC",
-      "AE",
-      "LAPW"
-    ],
-    "types": [
-      "DFT"
-    ],
-    "nomad_tags": [
-      "PI_member",
-      "data_collaboration"
-    ]
-  },
-  "octopus": {
-    "author_name": "Rubio",
-    "homepage": "https://www.tddft.org/programs/octopus/wiki/index.php/Main_Page",
-    "license": "OS(CL)",
-    "license_annotation": "GPL-2.0",
-    "name": "octopus",
-    "query_method": "search term",
-    "query_string": "octopus Rubio",
-    "tags": [
-      "PBC",
-      "PP",
-      "RS"
-    ],
-    "types": [
-      "DFT"
-    ],
-    "nomad_tags": [
-      "PI_member",
-      "data_collaboration"
-    ]
-  },
-  "xTB": {
-    "author_name": "Grimme",
-    "homepage": "https://xtb-docs.readthedocs.io/",
-    "license": "OS(CL)",
-    "license_annotation": "LGPL-3.0",
-    "name": "xTB",
-    "query_method": "search term",
-    "query_string": "xtb \"Grimme\"",
-    "tags": [],
-    "types": [
-      "TB"
-    ],
-    "nomad_tags": []
-  },
-  "Firefly": {
-    "author_name": "Granovsky",
-    "homepage": "http://classic.chem.msu.su/gran/gamess/index.html",
-    "license": "F",
-    "license_annotation": "Firefly Quantum Chemistry Package License Agreement",
-    "name": "Firefly",
-    "query_method": "search term",
-    "query_string": "firefly \"Granovsky\"",
-    "tags": [
-      "AE",
-      "GTO",
-      "PP"
-    ],
-    "types": [
-      "WFM",
-      "DFT"
-    ],
-    "nomad_tags": []
-  },
-  "Hyperchem": {
-    "author_name": "Hypercube",
-    "homepage": "http://www.hyper.com/?tabid=360",
-    "license": "C(C)",
-    "license_annotation": "",
-    "name": "Hyperchem",
-    "query_method": "search term",
-    "query_string": "hyperchem hypercube",
-    "tags": [
-      "GTO",
-      "PP"
-    ],
-    "types": [
-      "FF",
-      "WFM",
-      "DFT"
-    ],
-    "nomad_tags": []
-  },
-  "PySCF": {
-    "author_name": "Chan",
-    "homepage": "https://pyscf.org/",
-    "license": "OS(P)",
-    "license_annotation": "Apache-2.0",
-    "name": "PySCF",
-    "query_method": "search term",
-    "query_string": "pyscf \"chan\"",
-    "tags": [
-      "GTO",
-      "PP"
-    ],
-    "types": [
-      "WFM",
-      "DFT"
-    ],
-    "nomad_tags": []
-  },
-  "Desmond": {
-    "author_name": "Schr\u00f6dinger",
-    "homepage": "https://www.schrodinger.com/products/desmond",
-    "license": "F(A)",
-    "license_annotation": "",
-    "name": "Desmond",
-    "query_method": "search term",
-    "query_string": "desmond schr\u00f6dinger",
-    "tags": [],
-    "types": [
-      "FF"
-    ],
-    "nomad_tags": []
-  },
-  "OpenMM": {
-    "author_name": "Eastman",
-    "homepage": "http://openmm.org",
-    "license": "OS(P)",
-    "license_annotation": "MIT",
-    "name": "OpenMM",
-    "query_method": "search term",
-    "query_string": "openmm Eastman",
-    "tags": [],
-    "types": [
-      "FF"
-    ],
-    "nomad_tags": []
   },
   "Wannier90": {
     "author_name": "Marzari",
+    "benchmarks": [],
     "homepage": "http://www.wannier.org/",
     "license": "OS(CL)",
     "license_annotation": "GPL-2.0",
@@ -1223,6 +1216,103 @@
     ],
     "types": [
       "S"
+    ]
+  },
+  "YASARA": {
+    "author_name": "Krieger",
+    "benchmarks": [],
+    "homepage": "http://yasara.org/",
+    "license": "C(C)",
+    "license_annotation": null,
+    "name": "YASARA",
+    "nomad_tags": [],
+    "query_method": "search term",
+    "query_string": "YASARA Krieger",
+    "tags": [],
+    "types": [
+      "FF"
+    ]
+  },
+  "Yambo": {
+    "author_name": "Marini",
+    "benchmarks": [],
+    "homepage": "http://www.yambo-code.org/",
+    "license": "OS(CL)",
+    "license_annotation": "GPL-2.0",
+    "name": "Yambo",
+    "nomad_tags": [],
+    "query_method": "search term",
+    "query_string": "Yambo Marini",
+    "tags": [
+      "PBC",
+      "PP",
+      "PW"
+    ],
+    "types": [
+      "S"
+    ]
+  },
+  "exciting": {
+    "author_name": "Draxl",
+    "benchmarks": [
+      "Δ-value"
+    ],
+    "homepage": "http://exciting-code.org/",
+    "license": "OS(CL)",
+    "license_annotation": "GPL-2.0-or-later",
+    "name": "exciting",
+    "nomad_tags": [
+      "PI_member",
+      "data_collaboration"
+    ],
+    "query_method": "search term",
+    "query_string": "\"exciting\" code Draxl",
+    "tags": [
+      "PBC",
+      "AE",
+      "LAPW"
+    ],
+    "types": [
+      "DFT"
+    ]
+  },
+  "Octopus": {
+    "author_name": "Rubio",
+    "benchmarks": [
+      "Δ-value"
+    ],
+    "homepage": "https://www.tddft.org/programs/octopus/wiki/index.php/Main_Page",
+    "license": "OS(CL)",
+    "license_annotation": "GPL-2.0",
+    "name": "Octopus",
+    "nomad_tags": [
+      "PI_member",
+      "data_collaboration"
+    ],
+    "query_method": "search term",
+    "query_string": "octopus Rubio",
+    "tags": [
+      "PBC",
+      "PP",
+      "RS"
+    ],
+    "types": [
+      "DFT"
+    ]
+  },
+  "xTB": {
+    "author_name": "Grimme",
+    "benchmarks": [],
+    "homepage": "https://xtb-docs.readthedocs.io/",
+    "license": "OS(CL)",
+    "license_annotation": "LGPL-3.0",
+    "name": "xTB",
+    "nomad_tags": [],
+    "query_method": "search term",
+    "query_string": "xtb \"Grimme\"",
+    "tags": [],
+    "types": [
+      "TB"
     ]
   }
 }


### PR DESCRIPTION
Following feedback by reviewers, add a "benchmarks" column.
In order not to expand the maintenance effort, to begin with this column
only registers whether a given benchmark exists (starting with the
delta-value from [1]).

Including actual values of benchmarks in the list could be envisioned
in cases where benchmark web sites offer APIs.

[1] https://molmod.ugent.be/deltacodesdft