### PR TITLE
move "About" text to separate markdown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,32 +5,10 @@
 [atomistic.software](https://atomistic.software/#/) aims to track the citation trends of all major atomistic simulation engines.
 
 This git repository contains the source code of the [atomistic.software](https://atomistic.software/#/) website.
-
-## How to cite
-
-You are welcome to cite [atomistic.software](https://atomistic.software/#/) in your scientific work in the following ways:
-
-* **Variant 1**: Cite the DOI corresponding to the latest website release by copying the "Cite as" information from [https://doi.org/10.5281/zenodo.4639414](https://doi.org/10.5281/zenodo.4639414)
-* **Variant 2**: Talirz, L. *Trends in atomistic simulation engines.* [https://atomistic.software](https://atomistic.software/#/) (2021)
- 
-## Scope
-
-[atomistic.software](https://atomistic.software/#/) uses the following working definition of an *atomistic simulation engine*:
-
-> a piece of software that, given two sets of atomic elements and positions, can compute their (relative) internal energies. 
-> In almost all cases, engines will also be able to compute the derivative of the energy with respect to the positions, i.e. the forces on the atoms, and thus be able to perform tasks like geometry optimizations or molecular dynamics.
-
-This covers the `DFT`, `WFM`, `QMC`, `TB`, and `FF` categories.
-
-Softwares in the `Spectroscopy` category are not necessarily simulation engines in the above sense, but compute the response of a given atomic structure to an external excitation (via photons, electrons, ...).
-
-## Relevance criterion
-
-In order to keep the length of the list manageable, atomistic simulation engines need to have had at least **one year with 100 citations** or more in order to be added to the list.
 ## Adding a simulation engine
 
 Contributions of new simulation engines are always welcome!
-Please check that your engine fits the [scope](#scope) and meets the [relevance criterion](#relevance-criterion).
+Please check that your engine fits the **scope** and **relevance criterion** on [atomistic.software/#/about](https://atomistic.software/#/about).
 Then pick one of the following two options:
 #### Option 1: Suggest addition
 
@@ -43,11 +21,9 @@ If you're not familiar with GitHub or don't have time to add the engine yourself
 
 The second step can also be performed in an automated way by the maintainer of this repository.
 
-## License
+## How to cite
 
-The web application is licensed under the [Affero General Public License version 3 (AGPL-3.0-only)](./LICENSE).
-
-The data set in [src/data](./src/data) is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International license (CC-BY-SA-4.0)](http://creativecommons.org/licenses/by-sa/4.0/).
+See [atomistic.software/#/about](https://atomistic.software/#/about).
 
 ## Developing the app
 
@@ -58,11 +34,12 @@ and makes use of the great [mui-datatable](https://github.com/gregnb/mui-datatab
  * `npm test` launches the test runner in the interactive watch mode, see [running tests](https://facebook.github.io/create-react-app/docs/running-tests).
  * `npm run build` builds the app for production to the `build` folder (bundles React and optimizes for performance).
  * `npm run deploy` deploys the app to GitHub pages.
+## License
 
-## Acknowledgements
+The web application is licensed under the [Affero General Public License version 3 (AGPL-3.0-only)](./LICENSE).
+
+The data set in [src/data](./src/data) is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International license (CC-BY-SA-4.0)](http://creativecommons.org/licenses/by-sa/4.0/).
+
+## Acknowledgements & contact
 
 See [atomistic.software/#/about](https://atomistic.software/#/about) 
-
-## Contact
-
-leopold.talirz@gmail.com

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -1,6 +1,4 @@
-// import Chart from './Dashboard/Chart';
-// import Deposits from './Dashboard/Deposits';
-import React from "react";
+import React from 'react';
 import Typography from "@material-ui/core/Typography";
 import Grid from "@material-ui/core/Grid";
 import Paper from "@material-ui/core/Paper";
@@ -10,132 +8,65 @@ import useStyles from "./Dashboard/Styles";
 import Title from "./Dashboard/Title";
 import packageJson from "../../package.json";
 
-const aboutMD = `
-*${packageJson.name}* aims to track the citation trends of all major atomistic simulation engines (see [scope](${packageJson.repository.url}#scope) and [relevance criterion](${packageJson.repository.url}#relevance)).
+import aboutMD from '../text/about.md';
 
-This is a collaboratively edited list.
-Please visit the [source code repository on GitHub](${packageJson.repository.url}) for instructions on how to [add new simulation engines](${packageJson.repository.url}#adding-a-simulation-engine).
+const fillTemplate = function(templateString, templateVars){
+  /** 
+   * Replace JS variables in markdown strings.
+   * 
+   * See https://stackoverflow.com/a/37217166/1069467
+   */
+  // eslint-disable-next-line 
+    return new Function("return `"+templateString +"`;").call(templateVars);
+}
 
-`;
+class MarkdownPane extends React.Component {
+  /**
+   * Pane to display markdown content from file
+   * 
+   * Can be used with markdown file or markdown string:
+   * 
+   *   <MarkdownPane title="About" markdown={aboutMD} classes={classes} />
+       <MarkdownPane title="Methodology" markdownFile={methodologyMD} classes={classes} />
+   */
 
-const methodologyMD = `
+  constructor(props) {
+    super(props);
+    this.state = { 
+      title: props.title,
+      markdownFile: props.markdownFile,
+      markdown: props.markdown || '',
+      classes: props.classes,
+    };
+  }
 
-**Disclaimer**: Owing to the [lack of standardization in today's software citation practices](http://doi.org/10.5281/zenodo.4263762), the citation counts reported here are *approximate* and their significance should not be overrated.
-This is not an exact science.
-Nevertheless, [reports](${packageJson.repository.url}/issues) of mistakes or practical suggestions on how to improve accuracy are always welcome. 
+  componentWillMount() {
+    // Get contents from Markdown file and put them in the React state, so we can reference it in render() below.
+    if(!this.state.markdown && this.state.markdownFile) {
+    fetch(this.state.markdownFile).then(res => res.text()).then(text => this.setState({ markdown: fillTemplate(text,{'packageJson': packageJson} ) }));
+    }
+  }
 
-Approximate citation counts are obtained from [Google Scholar](https://scholar.google.com/) as follows:
-
- 1. Search for name of the code and the last name of a representative developer (vast majority of codes)
- 1. When the name of the code is too common a search term, citations of a major article are counted (minority of codes)
-
-Click on a citation count in order to see the exact Google Scholar query that was used to extract it.
-`;
-
-const faqMD = `
- *  **Q**: The citation count for year XXXX reported here differs somewhat from the same citation count I see on Google Scholar. Why?
-
-    **A**: Citation counts reported by Google Scholar are not static, even for years that lie in the past.
-    Reasons may include new sites being indexed, more text being extracted, different citations being disambiguated, or even the heuristic evolving that predicts the total number of results.
-    In our experience, citation data for the previous year can be subject to significant (upwards) fluctuation, while citation data for years further in the past are quite stable.
-    We record the date of when each data point was collected in the [source code repository](${packageJson.repository.url}).
-
-*  **Q**: Why impose a criterion that engines on the list need to have at least one year with 100 citations?
-
-    **A**: atomistic.software aims to be a comprehensive list of all major atomistic simulation engines.
-    As new engines are created all the time, this goal is almost impossible to achieve without introducing a "relevance cutoff".
-    The value of 100 is not set in stone and could be re-evaluated in the future, once the list has had some time to consolidate.
+  render() {
+    return  (   <Grid item xs={12}>
+    <Paper className={this.state.classes.paper}>
+      <React.Fragment>
+        <Title>{this.state.title}</Title>
+        <Typography component="div" variant="body1" className="markdown">
+          <ReactMarkdown source={this.state.markdown} />
+        </Typography>
+      </React.Fragment>
+    </Paper>
+  </Grid> );
     
-`;
-
-const acknowledgementsMD = `
-This project was inspired by and built upon the ["Major codes in electronic-structure theory, quantum chemistry, and molecular-dynamics"](https://www.nomad-coe.eu/old-pages/externals/codes) collection maintained by the [NOMAD Center of Excellence](https://www.nomad-coe.eu) from 2017-2019.
-Thanks go to Luca Ghiringhelli for being supportive of this effort to transform the static list into an interactive app and a collaborative project.
-
-The project draws upon further great resources, including:
- * The [Google Scholar](https://scholar.google.com/) search engine for citation counts
- * Wikipedia's [List of quantum chemistry and solid-state physics software](https://en.wikipedia.org/wiki/List_of_quantum_chemistry_and_solid-state_physics_software)
- * Wikipedia's [Comparison of software for molecular mechanics modelling](https://en.wikipedia.org/wiki/Comparison_of_software_for_molecular_mechanics_modeling)
- * SklogWiki's [Materials modelling and computer simulation codes](http://www.sklogwiki.org/SklogWiki/index.php/Materials_modelling_and_computer_simulation_codes)
-`;
-
-const contactMD = `
-This page is currently maintained by [${packageJson.author.name}](${packageJson.author.url}).
-`;
+  }
+}
 
 export default function Home() {
   const classes = useStyles();
   return (
     <Grid container spacing={3}>
-      {}
-      {/* About */}
-      <Grid item xs={12}>
-        <Paper className={classes.paper}>
-          <React.Fragment>
-            <Title>About</Title>
-            <Typography component="div" variant="body1">
-              <ReactMarkdown source={aboutMD} />
-            </Typography>
-          </React.Fragment>
-        </Paper>
-      </Grid>
-      {/* Methodology */}
-      <Grid item xs={12}>
-        <Paper className={classes.paper}>
-          <React.Fragment>
-            <Title>Methodology</Title>
-            <Typography component="div" variant="body1">
-              <ReactMarkdown source={methodologyMD} />
-            </Typography>
-          </React.Fragment>
-        </Paper>
-      </Grid>
-      {/* FAQ */}
-      <Grid item xs={12}>
-        <Paper className={classes.paper}>
-          <React.Fragment>
-            <Title>Frequently Asked Questions</Title>
-            <Typography component="div" variant="body1">
-              <ReactMarkdown source={faqMD} />
-            </Typography>
-          </React.Fragment>
-        </Paper>
-      </Grid>
-      {/* Acknowledgements */}
-      <Grid item xs={12}>
-        <Paper className={classes.paper}>
-          <React.Fragment>
-            <Title>Acknowledgements</Title>
-            <Typography component="div" variant="body1">
-              <ReactMarkdown source={acknowledgementsMD} />
-            </Typography>
-          </React.Fragment>
-        </Paper>
-      </Grid>
-      {/* Contact */}
-      <Grid item xs={12}>
-        <Paper className={classes.paper}>
-          <React.Fragment>
-            <Title>Contact</Title>
-            <Typography component="div" variant="body1">
-              <ReactMarkdown source={contactMD} />
-            </Typography>
-          </React.Fragment>
-        </Paper>
-      </Grid>
+      <MarkdownPane title="About" markdownFile={aboutMD} classes={classes} />
     </Grid>
   );
 }
-
-// {/* Chart */}
-// <Grid item xs={12} md={8} lg={9}>
-//     <Paper className={fixedHeightPaper}>
-//         <Chart />
-//     </Paper>
-// </Grid>
-// {/* Recent Deposits */}
-// <Grid item xs={12} md={4} lg={3}>
-//     <Paper className={fixedHeightPaper}>
-//         <Deposits />
-//     </Paper>
-// </Grid>

--- a/src/style.css
+++ b/src/style.css
@@ -27,3 +27,7 @@ img.zenodo {
 main.makeStyles-content-12 {
   height: 100%;
 }
+
+div.markdown h1, h2, h3, h4, h5, h6{
+  font-size: 1.2em;
+}

--- a/src/text/about.md
+++ b/src/text/about.md
@@ -1,0 +1,64 @@
+## Purpose
+
+*${this.packageJson.name}* aims to track the citation trends of all major atomistic simulation engines.
+
+Practitioners and software developers in the field of atomistic simulations may find it useful for:
+
+ * getting an overview of major simulation engines with specific features, licensing conditions, ...
+ * monitoring how the use of individual simulation engines has evolved over time
+ * analyzing trends at the ecosystem level (licensing, ...)
+
+Citation data are updated annually, while [corrections and additions](${this.packageJson.repository.url}#adding-a-simulation-engine) are welcome throughout the year.
+
+The collection does not aim to promote any particular simulation engine or group of engines.
+
+## Scope and relevance criterion
+
+*${this.packageJson.name}* uses the following working definition of an *atomistic simulation engine*:
+
+> a piece of software that, given two sets of atomic elements and positions, can compute their (relative) internal energies. 
+> In almost all cases, engines will also be able to compute the derivative of the energy with respect to the positions, i.e. the forces on the atoms, and thus be able to perform tasks like geometry optimizations or molecular dynamics.
+
+This covers the \`DFT\`, \`WFM\`, \`QMC\`, \`TB\`, and \`FF\` categories.
+Softwares in the \`Spectroscopy\` category are not necessarily simulation engines in the above sense, but compute the response of a given atomic structure to an external excitation (via photons, electrons, ...).
+
+**Relevance criterion**: In order to keep the length of the list manageable, atomistic simulation engines need to have had at least **one year with 100 citations** or more in order to be added to the list.
+
+## Methodology
+
+**Disclaimer**: Owing to the [lack of standardization in today's software citation practices](http://doi.org/10.5281/zenodo.4263762), the citation counts reported here are *approximate* and their significance should not be overrated.
+This is not an exact science.
+Nevertheless, [reports](${this.packageJson.repository.url}/issues) of mistakes or practical suggestions on how to improve accuracy are always welcome. 
+
+Approximate citation counts are obtained from [Google Scholar](https://scholar.google.com/) as follows:
+
+ 1. Search for name of the code and the last name of a representative developer (vast majority of codes)
+ 1. When the name of the code is too common a search term, citations of a major article are counted (minority of codes)
+
+Click on a citation count in order to see the exact Google Scholar query that was used to extract it.
+
+## Frequently Asked Questions
+
+ *  **Q**: The citation count for year XXXX reported here differs somewhat from the same citation count I see on Google Scholar. Why?
+
+    **A**: Citation counts reported by Google Scholar are not static, even for years that lie in the past.
+    Reasons may include new sites being indexed, more text being extracted, different citations being disambiguated, or even the heuristic evolving that predicts the total number of results.
+    In our experience, citation data for the previous year can be subject to significant (upwards) fluctuation, while citation data for years further in the past are quite stable.
+    We record the date of when each data point was collected in the [source code repository](${this.packageJson.repository.url}).
+
+*  **Q**: Why impose a criterion that engines on the list need to have at least one year with 100 citations?
+
+    **A**: atomistic.software aims to be a comprehensive list of all major atomistic simulation engines.
+    Since new engines are created all the time, this goal is almost impossible to achieve without introducing a "relevance cutoff".
+    The value of 100 is not set in stone and could be re-evaluated in the future, once the list has had some time to consolidate.
+
+## How to cite
+
+You are welcome to cite [atomistic.software](https://atomistic.software/#/) in your scientific work in the following ways:
+
+* **Variant 1**: Cite the DOI corresponding to the latest website release by copying the "Cite as" information from [https://doi.org/10.5281/zenodo.4639414](https://doi.org/10.5281/zenodo.4639414)
+* **Variant 2**: Talirz, L. *Trends in atomistic simulation engines.* [https://atomistic.software](https://atomistic.software/#/) (2021)
+
+## Contact
+
+This page is currently maintained by [${this.packageJson.author.name}](${this.packageJson.author.url}).


### PR DESCRIPTION
Editing a separate markdown file should make it easier for others to
contribute.

Also, reduce duplication between `README.md` and the new `about.md`.