### PR TITLE
underline abbreviations

### DIFF
--- a/src/components/Columns.js
+++ b/src/components/Columns.js
@@ -26,8 +26,8 @@ function TooltipText(tooltip, text) {
    * Tooltip with nicely spaced text that doesn't become a cursor.
    */
   return (
-    <Tooltip title={tooltip} placement="top-end" key={tooltip}>
-      <span style={{ cursor: "default", marginRight: "0.5em" }}>{text}</span>
+    <Tooltip title={tooltip} placement="top" key={tooltip} arrow>
+      <span className="has-tooltip">{text}</span>
     </Tooltip>
   );
   //return <Tooltip title={tooltip} placement="top-end" key={text} clickable={true}><span><Button disabled >{text}</Button></span></Tooltip>;

--- a/src/style.css
+++ b/src/style.css
@@ -31,3 +31,14 @@ main.makeStyles-content-12 {
 div.markdown h1, h2, h3, h4, h5, h6{
   font-size: 1.2em;
 }
+
+span.has-tooltip {
+  cursor: default;
+  margin-right: 0.5em;
+  text-decoration: underline dotted;
+  -webkit-text-decoration: underline dotted;
+}
+
+span.has-tooltip:hover {
+  text-decoration: none;
+}


### PR DESCRIPTION
Still using tooltip on hover but the abbreviations are now underlined
(and underline vanishes on hover).

Hover in general has the disadvantage of not supporting touch interfaces
but the alternative of displaying information on click requires to
transform all of the text in to buttons, which need to be listened to
etc.
It may work fine but it requires significant styling efforts.