### PR TITLE
Fix MOPAC citations

### DIFF
--- a/src/data/codes.json
+++ b/src/data/codes.json
@@ -838,7 +838,7 @@
     "notes": null,
     "query_method": "search term",
     "query_publication_id": null,
-    "query_string": "MOPAC Stewart",
+    "query_string": "MOPAC OR \"MOPAC93\" OR \"MOPAC97\" OR \"MOPAC2000\" OR \"MOPAC2007\" OR \"MOPAC2009\" OR \"MOPAC2012\" OR \"MOPAC2016\" -expressway -policing -\"Missouri Pacific\" -\"motif finding\" -\"primed amplification\" -\"MOPAC Blvd\" -\"MOPAC Boulevard\" -\"North MOPAC\" -\"Mopac Expy\"",
     "tags": ["PBC", "PP", "STO"],
     "types": ["FF", "WFM"]
   },


### PR DESCRIPTION
This performs the changes suggested in the Issue (#114) that I opened to fix MOPAC's citation count and remove ghost Google Scholar entries from all citation counts. I am more confident making adjustments in MOPAC's case because I've already studied its history of citations in detail. Ideally, to correct other codes similarly, someone needs to start from a very permissive search string and add restrictions to remove as many false positives as possible and check that the final false positive rate isn't too large. I'd say that having code author names in the search as required elements rather than part of some OR expression is too restrictive because many codes have a substantial number of citations that mention the code without referring to the standard citation paper. It's usually not as bad as in MOPAC's case, but for example with VASP & Gaussian this would add about 30% to their citation counts by my estimate.