### PR TITLE
update GROMOS query string

### DIFF
--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -166,8 +166,8 @@
         "datestamp": "2021-04-10"
       },
       "GROMOS": {
-        "citations": 777,
-        "datestamp": "2021-04-10"
+        "citations": 395,
+        "datestamp": "2023-02-28"
       },
       "GULP": {
         "citations": 267,
@@ -568,8 +568,8 @@
         "datestamp": "2021-01-17"
       },
       "GROMOS": {
-        "citations": 825,
-        "datestamp": "2021-01-17"
+        "citations": 378,
+        "datestamp": "2023-02-28"
       },
       "GULP": {
         "citations": 254,
@@ -978,8 +978,8 @@
         "datestamp": "2021-01-17"
       },
       "GROMOS": {
-        "citations": 1050,
-        "datestamp": "2021-01-17"
+        "citations": 518,
+        "datestamp": "2023-02-28"
       },
       "GULP": {
         "citations": 267,
@@ -1388,8 +1388,8 @@
         "datestamp": "2021-01-17"
       },
       "GROMOS": {
-        "citations": 1130,
-        "datestamp": "2021-01-17"
+        "citations": 553,
+        "datestamp": "2023-02-28"
       },
       "GULP": {
         "citations": 298,
@@ -1798,8 +1798,8 @@
         "datestamp": "2021-01-17"
       },
       "GROMOS": {
-        "citations": 1240,
-        "datestamp": "2021-01-17"
+        "citations": 564,
+        "datestamp": "2023-02-28"
       },
       "GULP": {
         "citations": 292,
@@ -2208,8 +2208,8 @@
         "datestamp": "2021-01-07"
       },
       "GROMOS": {
-        "citations": 1260,
-        "datestamp": "2021-01-07"
+        "citations": 585,
+        "datestamp": "2023-02-28"
       },
       "GULP": {
         "citations": 271,
@@ -2618,8 +2618,8 @@
         "datestamp": "2021-01-07"
       },
       "GROMOS": {
-        "citations": 1390,
-        "datestamp": "2021-01-07"
+        "citations": 652,
+        "datestamp": "2023-02-28"
       },
       "GULP": {
         "citations": 259,
@@ -3028,8 +3028,8 @@
         "datestamp": "2021-01-07"
       },
       "GROMOS": {
-        "citations": 1330,
-        "datestamp": "2021-01-07"
+        "citations": 609,
+        "datestamp": "2023-02-28"
       },
       "GULP": {
         "citations": 259,
@@ -3438,8 +3438,8 @@
         "datestamp": "2021-01-04"
       },
       "GROMOS": {
-        "citations": 1460,
-        "datestamp": "2021-01-04"
+        "citations": 697,
+        "datestamp": "2023-02-28"
       },
       "GULP": {
         "citations": 262,
@@ -3848,8 +3848,8 @@
         "datestamp": "2021-01-04"
       },
       "GROMOS": {
-        "citations": 1540,
-        "datestamp": "2021-01-04"
+        "citations": 664,
+        "datestamp": "2023-02-28"
       },
       "GULP": {
         "citations": 233,
@@ -4214,8 +4214,8 @@
         "datestamp": "2021-08-24"
       },
       "GROMOS": {
-        "citations": 1570,
-        "datestamp": "2021-08-24"
+        "citations": 699,
+        "datestamp": "2023-02-28"
       },
       "GULP": {
         "citations": 193,
@@ -4488,8 +4488,8 @@
         "datestamp": "2023-01-28"
       },
       "GROMOS": {
-        "citations": 1900,
-        "datestamp": "2023-01-30"
+        "citations": 747,
+        "datestamp": "2023-02-28"
       },
       "GULP": {
         "citations": 253,
@@ -4758,8 +4758,8 @@
         "datestamp": "2023-01-28"
       },
       "GROMOS": {
-        "citations": 2160,
-        "datestamp": "2023-01-28"
+        "citations": 771,
+        "datestamp": "2023-02-28"
       },
       "GULP": {
         "citations": 214,

--- a/src/data/codes.json
+++ b/src/data/codes.json
@@ -622,7 +622,7 @@
     "notes": "A GROMOS96 license is required in order to be able to run QM/MM simulations with CPMD.",
     "query_method": "search term",
     "query_publication_id": null,
-    "query_string": "GROMOS van Gunsteren",
+    "query_string": "\"GROMOS\" \"van Gunsteren\"",
     "tags": [],
     "types": ["FF"]
   },


### PR DESCRIPTION
Previous query string without quotation marks was catching numerous false positives (also matching GROMACS, etc.).