### PR TITLE
fix cutoff variable

### DIFF
--- a/src/components/Config.js
+++ b/src/components/Config.js
@@ -1,8 +1,8 @@
 import citations from "../data/citations.json";
 import codes from "../data/codes.json";
 
-// Citation cutoff
-const CUTOFF = 100;
+// Citation cutoff per year (~1 citation per week)
+const CUTOFF = 50;
 
 function yearToRange(year) {
   /**


### PR DESCRIPTION
CUTOFF variable in code was still set to 100, resulting in codes with <100 citations not showing up in the statistics page.