### PR TITLE
Feat/update 2024

### DIFF
--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -2522,420 +2522,308 @@
   "2016-2016": {
     "citations": {
       "ABINIT": {
-        "citations": 401,
-        "datestamp": "2021-01-07"
+        "citations": 393,
+        "datestamp": "2025-03-04"
       },
       "ACEMD": {
-        "citations": 64,
-        "datestamp": "2024-03-06"
-      },
-      "ACES": {
-        "citations": 35,
-        "datestamp": "2021-05-06"
+        "citations": 57,
+        "datestamp": "2025-03-04"
       },
       "ADF": {
-        "citations": 607,
-        "datestamp": "2021-01-07"
-      },
-      "ASW program package": {
-        "citations": 22,
-        "datestamp": "2021-01-17"
+        "citations": 599,
+        "datestamp": "2025-03-04"
       },
       "ATK/QuantumATK": {
-        "citations": 267,
-        "datestamp": "2021-06-16"
+        "citations": 259,
+        "datestamp": "2025-03-04"
       },
       "Amber": {
-        "citations": 1560,
-        "datestamp": "2021-01-07"
-      },
-      "BAGEL": {
-        "citations": 7,
-        "datestamp": "2021-01-07"
-      },
-      "BOSS": {
-        "citations": 18,
-        "datestamp": "2021-08-26"
+        "citations": 1600,
+        "datestamp": "2025-03-04"
       },
       "BerkeleyGW": {
-        "citations": 68,
-        "datestamp": "2023-01-30"
-      },
-      "BigDFT": {
-        "citations": 30,
-        "datestamp": "2021-01-07"
+        "citations": 70,
+        "datestamp": "2025-03-04"
       },
       "BoltzTrap": {
-        "citations": 251,
-        "datestamp": "2022-03-19"
+        "citations": 249,
+        "datestamp": "2025-03-04"
       },
       "CASINO": {
         "citations": 38,
-        "datestamp": "2025-01-26"
+        "datestamp": "2025-03-04"
       },
       "CASTEP": {
-        "citations": 1370,
-        "datestamp": "2021-06-30"
+        "citations": 1380,
+        "datestamp": "2025-03-04"
       },
       "CFOUR": {
-        "citations": 137,
-        "datestamp": "2021-01-07"
+        "citations": 135,
+        "datestamp": "2025-03-04"
       },
       "CHARMM": {
-        "citations": 876,
-        "datestamp": "2021-01-07"
+        "citations": 950,
+        "datestamp": "2025-03-04"
       },
       "COLUMBUS": {
-        "citations": 53,
-        "datestamp": "2025-01-26"
-      },
-      "CONQUEST O(N)": {
-        "citations": 37,
-        "datestamp": "2021-01-07"
-      },
-      "COSMOS-software": {
-        "citations": 36,
-        "datestamp": "2021-01-07"
+        "citations": 51,
+        "datestamp": "2025-03-04"
       },
       "CP2K": {
         "citations": 424,
-        "datestamp": "2021-05-06"
+        "datestamp": "2025-03-04"
       },
       "CPMD": {
         "citations": 319,
-        "datestamp": "2023-01-28"
+        "datestamp": "2025-03-04"
       },
       "CRYSTAL": {
-        "citations": 422,
-        "datestamp": "2021-04-10"
+        "citations": 419,
+        "datestamp": "2025-03-04"
       },
       "DFTB+": {
-        "citations": 144,
-        "datestamp": "2021-04-20"
+        "citations": 146,
+        "datestamp": "2025-03-04"
       },
       "DIRAC": {
-        "citations": 135,
-        "datestamp": "2021-01-07"
+        "citations": 123,
+        "datestamp": "2025-03-04"
       },
       "DL_POLY": {
-        "citations": 244,
-        "datestamp": "2021-01-07"
+        "citations": 234,
+        "datestamp": "2025-03-04"
       },
       "DMol3": {
-        "citations": 523,
-        "datestamp": "2021-04-10"
+        "citations": 603,
+        "datestamp": "2025-03-04"
       },
       "Dalton": {
-        "citations": 407,
-        "datestamp": "2021-01-07"
+        "citations": 416,
+        "datestamp": "2025-03-04"
       },
       "Desmond": {
-        "citations": 369,
-        "datestamp": "2021-01-17"
+        "citations": 370,
+        "datestamp": "2025-03-04"
       },
       "Discovery Studio": {
-        "citations": 1230,
-        "datestamp": "2021-01-07"
+        "citations": 1260,
+        "datestamp": "2025-03-04"
       },
       "EPW": {
         "citations": 21,
-        "datestamp": "2021-04-15"
-      },
-      "ERKALE": {
-        "citations": 7,
-        "datestamp": "2021-01-07"
+        "datestamp": "2025-03-04"
       },
       "ESPResSo": {
-        "citations": 86,
-        "datestamp": "2021-06-16"
+        "citations": 94,
+        "datestamp": "2025-03-04"
       },
       "Elk": {
-        "citations": 109,
-        "datestamp": "2021-04-19"
+        "citations": 108,
+        "datestamp": "2025-03-04"
       },
       "FEFF": {
-        "citations": 357,
-        "datestamp": "2021-01-07"
+        "citations": 353,
+        "datestamp": "2025-03-04"
       },
       "FHI-aims": {
-        "citations": 153,
-        "datestamp": "2021-01-07"
+        "citations": 149,
+        "datestamp": "2025-03-04"
       },
       "FLEUR": {
-        "citations": 45,
-        "datestamp": "2021-01-07"
+        "citations": 43,
+        "datestamp": "2025-03-04"
       },
       "FPLO": {
-        "citations": 107,
-        "datestamp": "2021-01-07"
+        "citations": 106,
+        "datestamp": "2025-03-04"
       },
       "Firefly": {
-        "citations": 244,
-        "datestamp": "2021-01-17"
+        "citations": 242,
+        "datestamp": "2025-03-04"
       },
       "FoldX": {
-        "citations": 131,
-        "datestamp": "2021-01-07"
+        "citations": 148,
+        "datestamp": "2025-03-04"
       },
       "GAMESS": {
-        "citations": 1010,
-        "datestamp": "2021-01-07"
+        "citations": 962,
+        "datestamp": "2025-03-04"
       },
       "GPAW": {
-        "citations": 178,
-        "datestamp": "2021-01-07"
-      },
-      "GPIUTMD": {
-        "citations": 1,
-        "datestamp": "2021-01-07"
+        "citations": 401,
+        "datestamp": "2025-03-04"
       },
       "GPUMD": {
         "citations": 0,
-        "datestamp": "2024-08-25"
+        "datestamp": "2025-03-04"
       },
       "GROMOS": {
-        "citations": 652,
-        "datestamp": "2023-02-28"
+        "citations": 605,
+        "datestamp": "2025-03-04"
       },
       "GULP": {
         "citations": 259,
-        "datestamp": "2021-08-26"
+        "datestamp": "2025-03-04"
       },
       "Gaussian": {
-        "citations": 11700,
-        "datestamp": "2022-02-03"
+        "citations": 11800,
+        "datestamp": "2025-03-04"
       },
       "Gromacs": {
-        "citations": 3000,
-        "datestamp": "2021-06-27"
+        "citations": 3070,
+        "datestamp": "2025-03-04"
       },
       "HOOMD-blue": {
-        "citations": 73,
-        "datestamp": "2021-01-07"
+        "citations": 74,
+        "datestamp": "2025-03-04"
       },
       "Hyperchem": {
-        "citations": 463,
-        "datestamp": "2021-01-17"
+        "citations": 465,
+        "datestamp": "2025-03-04"
       },
       "JDFTx": {
         "citations": 17,
-        "datestamp": "2024-03-06"
+        "datestamp": "2025-03-04"
       },
       "Jaguar": {
-        "citations": 287,
-        "datestamp": "2024-03-06"
+        "citations": 288,
+        "datestamp": "2025-03-04"
       },
       "LAMMPS": {
-        "citations": 2560,
-        "datestamp": "2024-03-29"
-      },
-      "LibAtoms / QUIP / GAP": {
-        "citations": 3,
-        "datestamp": "2021-01-07"
-      },
-      "MADNESS": {
-        "citations": 15,
-        "datestamp": "2021-01-07"
-      },
-      "MCCCS Towhee": {
-        "citations": 46,
-        "datestamp": "2021-01-07"
+        "citations": 2520,
+        "datestamp": "2025-03-04"
       },
       "MOE": {
-        "citations": 849,
-        "datestamp": "2021-01-07"
-      },
-      "MOIL": {
-        "citations": 18,
-        "datestamp": "2021-01-07"
+        "citations": 842,
+        "datestamp": "2025-03-04"
       },
       "MOLCAS": {
-        "citations": 292,
-        "datestamp": "2022-03-20"
+        "citations": 285,
+        "datestamp": "2025-03-04"
       },
       "MOPAC": {
-        "citations": 997,
-        "datestamp": "2022-04-15"
-      },
-      "MPQC": {
-        "citations": 8,
-        "datestamp": "2021-01-07"
+        "citations": 1050,
+        "datestamp": "2025-03-04"
       },
       "MacroModel": {
-        "citations": 419,
-        "datestamp": "2021-01-07"
+        "citations": 427,
+        "datestamp": "2025-03-04"
       },
       "Molpro": {
-        "citations": 829,
-        "datestamp": "2021-01-07"
+        "citations": 803,
+        "datestamp": "2025-03-04"
       },
       "NAMD": {
-        "citations": 1210,
-        "datestamp": "2024-03-29"
-      },
-      "NRLMOL": {
-        "citations": 19,
-        "datestamp": "2021-01-07"
+        "citations": 1180,
+        "datestamp": "2025-03-04"
       },
       "NWChem": {
-        "citations": 377,
-        "datestamp": "2021-08-31"
+        "citations": 361,
+        "datestamp": "2025-03-04"
       },
       "ONETEP": {
-        "citations": 50,
-        "datestamp": "2024-03-09"
+        "citations": 47,
+        "datestamp": "2025-03-04"
       },
       "ORCA": {
-        "citations": 769,
-        "datestamp": "2021-01-07"
+        "citations": 764,
+        "datestamp": "2025-03-04"
       },
       "Octopus": {
-        "citations": 178,
-        "datestamp": "2021-01-07"
+        "citations": 182,
+        "datestamp": "2025-03-04"
       },
       "OpenMM": {
-        "citations": 83,
-        "datestamp": "2021-01-17"
+        "citations": 77,
+        "datestamp": "2025-03-04"
       },
       "OpenMX": {
-        "citations": 101,
-        "datestamp": "2021-01-07"
+        "citations": 103,
+        "datestamp": "2025-03-04"
       },
       "OpenMolcas": {
         "citations": 0,
-        "datestamp": "2022-03-20"
-      },
-      "PARSEC": {
-        "citations": 52,
-        "datestamp": "2021-01-07"
-      },
-      "PLATO": {
-        "citations": 2,
-        "datestamp": "2021-01-07"
-      },
-      "PWPAW / ATOMPAW": {
-        "citations": 36,
-        "datestamp": "2021-01-07"
+        "datestamp": "2025-03-04"
       },
       "PWmat": {
         "citations": 3,
-        "datestamp": "2024-03-06"
+        "datestamp": "2025-03-04"
       },
       "Psi4": {
-        "citations": 91,
-        "datestamp": "2021-01-07"
+        "citations": 88,
+        "datestamp": "2025-03-04"
       },
       "PySCF": {
         "citations": 12,
-        "datestamp": "2021-01-17"
-      },
-      "Q": {
-        "citations": 18,
-        "datestamp": "2021-01-07"
+        "datestamp": "2025-03-04"
       },
       "Q-Chem": {
-        "citations": 442,
-        "datestamp": "2021-01-07"
+        "citations": 439,
+        "datestamp": "2025-03-04"
       },
       "QMCPACK": {
         "citations": 21,
-        "datestamp": "2024-03-09"
-      },
-      "Qbox": {
-        "citations": 21,
-        "datestamp": "2021-01-07"
+        "datestamp": "2025-03-04"
       },
       "Quantum ESPRESSO": {
-        "citations": 1540,
-        "datestamp": "2021-01-07"
+        "citations": 1550,
+        "datestamp": "2025-03-04"
       },
       "RASPA": {
-        "citations": 55,
-        "datestamp": "2021-04-24"
-      },
-      "RMCprofile": {
-        "citations": 27,
-        "datestamp": "2021-01-07"
-      },
-      "RedMD": {
-        "citations": 4,
-        "datestamp": "2021-01-07"
-      },
-      "S / PHI / nX": {
-        "citations": 5,
-        "datestamp": "2021-01-17"
+        "citations": 56,
+        "datestamp": "2025-03-04"
       },
       "SIESTA": {
-        "citations": 830,
-        "datestamp": "2021-01-07"
-      },
-      "Smeagol": {
-        "citations": 31,
-        "datestamp": "2021-01-07"
+        "citations": 832,
+        "datestamp": "2025-03-04"
       },
       "TB-LMTO-ASA": {
         "citations": 118,
-        "datestamp": "2021-06-27"
+        "datestamp": "2025-03-04"
       },
       "TINKER": {
-        "citations": 478,
-        "datestamp": "2023-01-28"
-      },
-      "TREMOLO-X": {
-        "citations": 3,
-        "datestamp": "2021-01-07"
+        "citations": 461,
+        "datestamp": "2025-03-04"
       },
       "TURBOMOLE": {
-        "citations": 648,
-        "datestamp": "2021-01-07"
+        "citations": 656,
+        "datestamp": "2025-03-04"
       },
       "TeraChem": {
-        "citations": 48,
-        "datestamp": "2022-01-10"
+        "citations": 45,
+        "datestamp": "2025-03-04"
       },
       "VASP": {
-        "citations": 6310,
-        "datestamp": "2024-03-29"
-      },
-      "WEST": {
-        "citations": 41,
-        "datestamp": "2021-01-07"
-      },
-      "WHAT IF": {
-        "citations": 145,
-        "datestamp": "2021-06-30"
+        "citations": 6240,
+        "datestamp": "2025-03-04"
       },
       "WIEN2k": {
-        "citations": 1200,
-        "datestamp": "2021-01-07"
+        "citations": 1190,
+        "datestamp": "2025-03-04"
       },
       "Wannier90": {
-        "citations": 188,
-        "datestamp": "2021-04-12"
+        "citations": 192,
+        "datestamp": "2025-03-04"
       },
       "YASARA": {
-        "citations": 298,
-        "datestamp": "2021-01-07"
+        "citations": 294,
+        "datestamp": "2025-03-04"
       },
       "Yambo": {
         "citations": 77,
-        "datestamp": "2021-01-07"
+        "datestamp": "2025-03-04"
       },
       "deMon2k": {
-        "citations": 60,
-        "datestamp": "2024-03-06"
+        "citations": 62,
+        "datestamp": "2025-03-04"
       },
       "exciting": {
-        "citations": 26,
-        "datestamp": "2024-03-06"
-      },
-      "gSAFT": {
-        "citations": 10,
-        "datestamp": "2021-01-07"
+        "citations": 29,
+        "datestamp": "2025-03-04"
       },
       "xTB": {
-        "citations": 6,
-        "datestamp": "2021-01-17"
+        "citations": 5,
+        "datestamp": "2025-03-04"
       }
     },
     "year_high": 2016,

--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -5462,5 +5462,311 @@
     },
     "year_high": 2023,
     "year_low": 2023
+  },
+  "2024-2024": {
+    "citations": {
+      "ABINIT": {
+        "citations": 381,
+        "datestamp": "2025-01-26"
+      },
+      "ACEMD": {
+        "citations": 67,
+        "datestamp": "2025-01-26"
+      },
+      "ADF": {
+        "citations": 568,
+        "datestamp": "2025-01-26"
+      },
+      "ATK/QuantumATK": {
+        "citations": 823,
+        "datestamp": "2025-01-26"
+      },
+      "Amber": {
+        "citations": 2430,
+        "datestamp": "2025-01-26"
+      },
+      "BerkeleyGW": {
+        "citations": 127,
+        "datestamp": "2025-01-26"
+      },
+      "BoltzTrap": {
+        "citations": 1020,
+        "datestamp": "2025-01-26"
+      },
+      "CASTEP": {
+        "citations": 3000,
+        "datestamp": "2025-01-26"
+      },
+      "CFOUR": {
+        "citations": 186,
+        "datestamp": "2025-01-26"
+      },
+      "CHARMM": {
+        "citations": 921,
+        "datestamp": "2025-01-26"
+      },
+      "COLUMBUS": {
+        "citations": 48,
+        "datestamp": "2025-01-26"
+      },
+      "CP2K": {
+        "citations": 1430,
+        "datestamp": "2025-01-26"
+      },
+      "CPMD": {
+        "citations": 191,
+        "datestamp": "2025-01-26"
+      },
+      "CRYSTAL": {
+        "citations": 358,
+        "datestamp": "2025-01-26"
+      },
+      "DFTB+": {
+        "citations": 79,
+        "datestamp": "2025-01-26"
+      },
+      "DIRAC": {
+        "citations": 196,
+        "datestamp": "2025-01-26"
+      },
+      "DL_POLY": {
+        "citations": 139,
+        "datestamp": "2025-01-26"
+      },
+      "DMol3": {
+        "citations": 976,
+        "datestamp": "2025-01-26"
+      },
+      "Dalton": {
+        "citations": 471,
+        "datestamp": "2025-01-26"
+      },
+      "Desmond": {
+        "citations": 2490,
+        "datestamp": "2025-01-26"
+      },
+      "Discovery Studio": {
+        "citations": 1060,
+        "datestamp": "2025-01-26"
+      },
+      "EPW": {
+        "citations": 283,
+        "datestamp": "2025-01-26"
+      },
+      "ESPResSo": {
+        "citations": 131,
+        "datestamp": "2025-01-26"
+      },
+      "Elk": {
+        "citations": 71,
+        "datestamp": "2025-01-26"
+      },
+      "FEFF": {
+        "citations": 235,
+        "datestamp": "2025-01-26"
+      },
+      "FHI-aims": {
+        "citations": 281,
+        "datestamp": "2025-01-26"
+      },
+      "FLEUR": {
+        "citations": 62,
+        "datestamp": "2025-01-26"
+      },
+      "FPLO": {
+        "citations": 190,
+        "datestamp": "2025-01-26"
+      },
+      "Firefly": {
+        "citations": 102,
+        "datestamp": "2025-01-26"
+      },
+      "FoldX": {
+        "citations": 354,
+        "datestamp": "2025-01-26"
+      },
+      "GAMESS": {
+        "citations": 616,
+        "datestamp": "2025-01-26"
+      },
+      "GPAW": {
+        "citations": 435,
+        "datestamp": "2025-01-26"
+      },
+      "GPUMD": {
+        "citations": 127,
+        "datestamp": "2025-01-26"
+      },
+      "GROMOS": {
+        "citations": 641,
+        "datestamp": "2025-01-26"
+      },
+      "GULP": {
+        "citations": 219,
+        "datestamp": "2025-01-26"
+      },
+      "Gaussian": {
+        "citations": 10300,
+        "datestamp": "2025-01-26"
+      },
+      "Gromacs": {
+        "citations": 7500,
+        "datestamp": "2025-01-26"
+      },
+      "HOOMD-blue": {
+        "citations": 199,
+        "datestamp": "2025-01-26"
+      },
+      "Hyperchem": {
+        "citations": 235,
+        "datestamp": "2025-01-26"
+      },
+      "JDFTx": {
+        "citations": 86,
+        "datestamp": "2025-01-26"
+      },
+      "Jaguar": {
+        "citations": 338,
+        "datestamp": "2025-01-26"
+      },
+      "LAMMPS": {
+        "citations": 4960,
+        "datestamp": "2025-01-26"
+      },
+      "MOE": {
+        "citations": 1090,
+        "datestamp": "2025-01-26"
+      },
+      "MOLCAS": {
+        "citations": 193,
+        "datestamp": "2025-01-26"
+      },
+      "MOPAC": {
+        "citations": 933,
+        "datestamp": "2025-01-26"
+      },
+      "MacroModel": {
+        "citations": 376,
+        "datestamp": "2025-01-26"
+      },
+      "Molpro": {
+        "citations": 798,
+        "datestamp": "2025-01-26"
+      },
+      "NAMD": {
+        "citations": 1480,
+        "datestamp": "2025-01-26"
+      },
+      "NWChem": {
+        "citations": 266,
+        "datestamp": "2025-01-26"
+      },
+      "ONETEP": {
+        "citations": 42,
+        "datestamp": "2025-01-26"
+      },
+      "ORCA": {
+        "citations": 3670,
+        "datestamp": "2025-01-26"
+      },
+      "Octopus": {
+        "citations": 353,
+        "datestamp": "2025-01-26"
+      },
+      "OpenMM": {
+        "citations": 1130,
+        "datestamp": "2025-01-26"
+      },
+      "OpenMX": {
+        "citations": 160,
+        "datestamp": "2025-01-26"
+      },
+      "OpenMolcas": {
+        "citations": 206,
+        "datestamp": "2025-01-26"
+      },
+      "PWmat": {
+        "citations": 125,
+        "datestamp": "2025-01-26"
+      },
+      "Psi4": {
+        "citations": 256,
+        "datestamp": "2025-01-26"
+      },
+      "PySCF": {
+        "citations": 488,
+        "datestamp": "2025-01-26"
+      },
+      "Q-Chem": {
+        "citations": 526,
+        "datestamp": "2025-01-26"
+      },
+      "QMCPACK": {
+        "citations": 62,
+        "datestamp": "2025-01-26"
+      },
+      "Quantum ESPRESSO": {
+        "citations": 3870,
+        "datestamp": "2025-01-26"
+      },
+      "RASPA": {
+        "citations": 282,
+        "datestamp": "2025-01-26"
+      },
+      "SIESTA": {
+        "citations": 751,
+        "datestamp": "2025-01-26"
+      },
+      "TB-LMTO-ASA": {
+        "citations": 44,
+        "datestamp": "2025-01-26"
+      },
+      "TINKER": {
+        "citations": 360,
+        "datestamp": "2025-01-26"
+      },
+      "TURBOMOLE": {
+        "citations": 592,
+        "datestamp": "2025-01-26"
+      },
+      "TeraChem": {
+        "citations": 97,
+        "datestamp": "2025-01-26"
+      },
+      "VASP": {
+        "citations": 14200,
+        "datestamp": "2025-01-26"
+      },
+      "WIEN2k": {
+        "citations": 1750,
+        "datestamp": "2025-01-26"
+      },
+      "Wannier90": {
+        "citations": 1010,
+        "datestamp": "2025-01-26"
+      },
+      "YASARA": {
+        "citations": 492,
+        "datestamp": "2025-01-26"
+      },
+      "Yambo": {
+        "citations": 151,
+        "datestamp": "2025-01-26"
+      },
+      "deMon2k": {
+        "citations": 50,
+        "datestamp": "2025-01-26"
+      },
+      "exciting": {
+        "citations": 62,
+        "datestamp": "2025-01-26"
+      },
+      "xTB": {
+        "citations": 1220,
+        "datestamp": "2025-01-26"
+      }
+    },
+    "year_high": 2024,
+    "year_low": 2024
   }
 }

--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -4693,307 +4693,307 @@
     "citations": {
       "ABINIT": {
         "citations": 307,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "ACEMD": {
         "citations": 66,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "ADF": {
         "citations": 523,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "ATK/QuantumATK": {
         "citations": 730,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "Amber": {
         "citations": 2230,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "BerkeleyGW": {
         "citations": 112,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "BoltzTrap": {
-        "citations": 676,
-        "datestamp": "2025-02-25"
+        "citations": 678,
+        "datestamp": "2025-03-04"
       },
       "CASINO": {
-        "citations": 61,
-        "datestamp": "2025-01-26"
+        "citations": 59,
+        "datestamp": "2025-03-04"
       },
       "CASTEP": {
-        "citations": 2330,
-        "datestamp": "2025-02-25"
+        "citations": 2550,
+        "datestamp": "2025-03-04"
       },
       "CFOUR": {
         "citations": 157,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "CHARMM": {
         "citations": 842,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "COLUMBUS": {
         "citations": 49,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "CP2K": {
-        "citations": 962,
-        "datestamp": "2025-02-25"
+        "citations": 963,
+        "datestamp": "2025-03-04"
       },
       "CPMD": {
         "citations": 199,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "CRYSTAL": {
         "citations": 355,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "DFTB+": {
         "citations": 82,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "DIRAC": {
         "citations": 157,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "DL_POLY": {
         "citations": 147,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "DMol3": {
-        "citations": 767,
-        "datestamp": "2025-02-25"
+        "citations": 768,
+        "datestamp": "2025-03-04"
       },
       "Dalton": {
-        "citations": 412,
-        "datestamp": "2025-02-25"
+        "citations": 413,
+        "datestamp": "2025-03-04"
       },
       "Desmond": {
         "citations": 1770,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "Discovery Studio": {
-        "citations": 956,
-        "datestamp": "2025-02-25"
+        "citations": 958,
+        "datestamp": "2025-03-04"
       },
       "EPW": {
-        "citations": 204,
-        "datestamp": "2025-02-25"
+        "citations": 205,
+        "datestamp": "2025-03-04"
       },
       "ESPResSo": {
         "citations": 111,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "Elk": {
         "citations": 69,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "FEFF": {
         "citations": 223,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "FHI-aims": {
         "citations": 222,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "FLEUR": {
         "citations": 56,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "FPLO": {
         "citations": 110,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "Firefly": {
-        "citations": 104,
-        "datestamp": "2025-02-25"
+        "citations": 105,
+        "datestamp": "2025-03-04"
       },
       "FoldX": {
         "citations": 299,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "GAMESS": {
-        "citations": 668,
-        "datestamp": "2025-02-25"
+        "citations": 669,
+        "datestamp": "2025-03-04"
       },
       "GPAW": {
-        "citations": 302,
-        "datestamp": "2025-02-25"
+        "citations": 301,
+        "datestamp": "2025-03-04"
       },
       "GPUMD": {
         "citations": 62,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "GROMOS": {
         "citations": 630,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "GULP": {
         "citations": 231,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "Gaussian": {
         "citations": 13000,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "Gromacs": {
-        "citations": 5950,
-        "datestamp": "2025-02-25"
+        "citations": 5960,
+        "datestamp": "2025-03-06"
       },
       "HOOMD-blue": {
         "citations": 163,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "Hyperchem": {
-        "citations": 229,
-        "datestamp": "2025-02-25"
+        "citations": 230,
+        "datestamp": "2025-03-06"
       },
       "JDFTx": {
         "citations": 69,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "Jaguar": {
         "citations": 319,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "LAMMPS": {
         "citations": 4210,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "MOE": {
         "citations": 1060,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "MOLCAS": {
         "citations": 169,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "MOPAC": {
-        "citations": 935,
-        "datestamp": "2025-02-25"
+        "citations": 937,
+        "datestamp": "2025-03-06"
       },
       "MacroModel": {
         "citations": 485,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "Molpro": {
         "citations": 710,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "NAMD": {
         "citations": 1270,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "NWChem": {
         "citations": 249,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "ONETEP": {
         "citations": 49,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "ORCA": {
-        "citations": 2600,
-        "datestamp": "2025-02-25"
+        "citations": 2610,
+        "datestamp": "2025-03-06"
       },
       "Octopus": {
-        "citations": 408,
-        "datestamp": "2025-02-25"
+        "citations": 409,
+        "datestamp": "2025-03-06"
       },
       "OpenMM": {
-        "citations": 838,
-        "datestamp": "2025-02-25"
+        "citations": 840,
+        "datestamp": "2025-03-06"
       },
       "OpenMX": {
         "citations": 146,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "OpenMolcas": {
         "citations": 179,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "PWmat": {
         "citations": 88,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "Psi4": {
         "citations": 220,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "PySCF": {
         "citations": 249,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "Q-Chem": {
-        "citations": 498,
-        "datestamp": "2025-02-25"
+        "citations": 499,
+        "datestamp": "2025-03-06"
       },
       "QMCPACK": {
         "citations": 63,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "Quantum ESPRESSO": {
-        "citations": 3240,
-        "datestamp": "2025-02-25"
+        "citations": 3260,
+        "datestamp": "2025-03-06"
       },
       "RASPA": {
         "citations": 234,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "SIESTA": {
-        "citations": 723,
-        "datestamp": "2025-02-25"
+        "citations": 725,
+        "datestamp": "2025-03-06"
       },
       "TB-LMTO-ASA": {
         "citations": 57,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "TINKER": {
         "citations": 423,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "TURBOMOLE": {
         "citations": 497,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "TeraChem": {
         "citations": 86,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "VASP": {
         "citations": 11600,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "WIEN2k": {
         "citations": 1230,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "Wannier90": {
         "citations": 662,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "YASARA": {
         "citations": 451,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "Yambo": {
         "citations": 127,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-06"
       },
       "deMon2k": {
-        "citations": 59,
-        "datestamp": "2025-02-25"
+        "citations": 60,
+        "datestamp": "2025-03-04"
       },
       "exciting": {
         "citations": 45,
-        "datestamp": "2025-02-25"
+        "datestamp": "2025-03-04"
       },
       "xTB": {
-        "citations": 795,
-        "datestamp": "2025-02-25"
+        "citations": 796,
+        "datestamp": "2025-03-06"
       }
     },
     "year_high": 2023,

--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -5466,304 +5466,304 @@
   "2024-2024": {
     "citations": {
       "ABINIT": {
-        "citations": 381,
-        "datestamp": "2025-01-26"
+        "citations": 349,
+        "datestamp": "2025-02-23"
       },
       "ACEMD": {
-        "citations": 67,
-        "datestamp": "2025-01-26"
+        "citations": 64,
+        "datestamp": "2025-02-23"
       },
       "ADF": {
-        "citations": 568,
-        "datestamp": "2025-01-26"
+        "citations": 556,
+        "datestamp": "2025-02-23"
       },
       "ATK/QuantumATK": {
-        "citations": 823,
-        "datestamp": "2025-01-26"
+        "citations": 806,
+        "datestamp": "2025-02-23"
       },
       "Amber": {
-        "citations": 2430,
-        "datestamp": "2025-01-26"
+        "citations": 2450,
+        "datestamp": "2025-02-23"
       },
       "BerkeleyGW": {
-        "citations": 127,
-        "datestamp": "2025-01-26"
+        "citations": 124,
+        "datestamp": "2025-02-23"
       },
       "BoltzTrap": {
-        "citations": 1020,
-        "datestamp": "2025-01-26"
+        "citations": 929,
+        "datestamp": "2025-02-23"
       },
       "CASTEP": {
-        "citations": 3000,
-        "datestamp": "2025-01-26"
+        "citations": 3110,
+        "datestamp": "2025-02-23"
       },
       "CFOUR": {
-        "citations": 186,
-        "datestamp": "2025-01-26"
+        "citations": 182,
+        "datestamp": "2025-02-23"
       },
       "CHARMM": {
-        "citations": 921,
-        "datestamp": "2025-01-26"
+        "citations": 891,
+        "datestamp": "2025-02-23"
       },
       "COLUMBUS": {
-        "citations": 48,
-        "datestamp": "2025-01-26"
+        "citations": 46,
+        "datestamp": "2025-02-23"
       },
       "CP2K": {
-        "citations": 1430,
-        "datestamp": "2025-01-26"
+        "citations": 1360,
+        "datestamp": "2025-02-23"
       },
       "CPMD": {
-        "citations": 191,
-        "datestamp": "2025-01-26"
+        "citations": 187,
+        "datestamp": "2025-02-23"
       },
       "CRYSTAL": {
-        "citations": 358,
-        "datestamp": "2025-01-26"
+        "citations": 329,
+        "datestamp": "2025-02-23"
       },
       "DFTB+": {
         "citations": 79,
-        "datestamp": "2025-01-26"
+        "datestamp": "2025-02-23"
       },
       "DIRAC": {
-        "citations": 196,
-        "datestamp": "2025-01-26"
+        "citations": 180,
+        "datestamp": "2025-02-23"
       },
       "DL_POLY": {
-        "citations": 139,
-        "datestamp": "2025-01-26"
+        "citations": 133,
+        "datestamp": "2025-02-23"
       },
       "DMol3": {
-        "citations": 976,
-        "datestamp": "2025-01-26"
+        "citations": 819,
+        "datestamp": "2025-02-23"
       },
       "Dalton": {
-        "citations": 471,
-        "datestamp": "2025-01-26"
+        "citations": 428,
+        "datestamp": "2025-02-23"
       },
       "Desmond": {
-        "citations": 2490,
-        "datestamp": "2025-01-26"
+        "citations": 2230,
+        "datestamp": "2025-02-23"
       },
       "Discovery Studio": {
-        "citations": 1060,
-        "datestamp": "2025-01-26"
+        "citations": 1010,
+        "datestamp": "2025-02-23"
       },
       "EPW": {
-        "citations": 283,
-        "datestamp": "2025-01-26"
+        "citations": 266,
+        "datestamp": "2025-02-23"
       },
       "ESPResSo": {
-        "citations": 131,
-        "datestamp": "2025-01-26"
+        "citations": 111,
+        "datestamp": "2025-02-23"
       },
       "Elk": {
-        "citations": 71,
-        "datestamp": "2025-01-26"
+        "citations": 70,
+        "datestamp": "2025-02-23"
       },
       "FEFF": {
-        "citations": 235,
-        "datestamp": "2025-01-26"
+        "citations": 222,
+        "datestamp": "2025-02-23"
       },
       "FHI-aims": {
-        "citations": 281,
-        "datestamp": "2025-01-26"
+        "citations": 259,
+        "datestamp": "2025-02-23"
       },
       "FLEUR": {
-        "citations": 62,
-        "datestamp": "2025-01-26"
+        "citations": 60,
+        "datestamp": "2025-02-23"
       },
       "FPLO": {
-        "citations": 190,
-        "datestamp": "2025-01-26"
+        "citations": 177,
+        "datestamp": "2025-02-23"
       },
       "Firefly": {
-        "citations": 102,
-        "datestamp": "2025-01-26"
+        "citations": 97,
+        "datestamp": "2025-02-23"
       },
       "FoldX": {
-        "citations": 354,
-        "datestamp": "2025-01-26"
+        "citations": 320,
+        "datestamp": "2025-02-23"
       },
       "GAMESS": {
-        "citations": 616,
-        "datestamp": "2025-01-26"
+        "citations": 578,
+        "datestamp": "2025-02-23"
       },
       "GPAW": {
-        "citations": 435,
-        "datestamp": "2025-01-26"
+        "citations": 413,
+        "datestamp": "2025-02-23"
       },
       "GPUMD": {
-        "citations": 127,
-        "datestamp": "2025-01-26"
+        "citations": 125,
+        "datestamp": "2025-02-23"
       },
       "GROMOS": {
-        "citations": 641,
-        "datestamp": "2025-01-26"
+        "citations": 613,
+        "datestamp": "2025-02-23"
       },
       "GULP": {
-        "citations": 219,
-        "datestamp": "2025-01-26"
+        "citations": 210,
+        "datestamp": "2025-02-23"
       },
       "Gaussian": {
-        "citations": 10300,
-        "datestamp": "2025-01-26"
+        "citations": 13700,
+        "datestamp": "2025-02-23"
       },
       "Gromacs": {
-        "citations": 7500,
-        "datestamp": "2025-01-26"
+        "citations": 7260,
+        "datestamp": "2025-02-23"
       },
       "HOOMD-blue": {
-        "citations": 199,
-        "datestamp": "2025-01-26"
+        "citations": 192,
+        "datestamp": "2025-02-23"
       },
       "Hyperchem": {
-        "citations": 235,
-        "datestamp": "2025-01-26"
+        "citations": 219,
+        "datestamp": "2025-02-23"
       },
       "JDFTx": {
-        "citations": 86,
-        "datestamp": "2025-01-26"
+        "citations": 83,
+        "datestamp": "2025-02-23"
       },
       "Jaguar": {
-        "citations": 338,
-        "datestamp": "2025-01-26"
+        "citations": 331,
+        "datestamp": "2025-02-23"
       },
       "LAMMPS": {
-        "citations": 4960,
-        "datestamp": "2025-01-26"
+        "citations": 4530,
+        "datestamp": "2025-02-23"
       },
       "MOE": {
-        "citations": 1090,
-        "datestamp": "2025-01-26"
+        "citations": 1040,
+        "datestamp": "2025-02-23"
       },
       "MOLCAS": {
-        "citations": 193,
-        "datestamp": "2025-01-26"
+        "citations": 179,
+        "datestamp": "2025-02-23"
       },
       "MOPAC": {
-        "citations": 933,
-        "datestamp": "2025-01-26"
+        "citations": 828,
+        "datestamp": "2025-02-23"
       },
       "MacroModel": {
-        "citations": 376,
-        "datestamp": "2025-01-26"
+        "citations": 387,
+        "datestamp": "2025-02-23"
       },
       "Molpro": {
-        "citations": 798,
-        "datestamp": "2025-01-26"
+        "citations": 759,
+        "datestamp": "2025-02-23"
       },
       "NAMD": {
-        "citations": 1480,
-        "datestamp": "2025-01-26"
+        "citations": 1430,
+        "datestamp": "2025-02-23"
       },
       "NWChem": {
-        "citations": 266,
-        "datestamp": "2025-01-26"
+        "citations": 275,
+        "datestamp": "2025-02-23"
       },
       "ONETEP": {
-        "citations": 42,
-        "datestamp": "2025-01-26"
+        "citations": 39,
+        "datestamp": "2025-02-23"
       },
       "ORCA": {
-        "citations": 3670,
-        "datestamp": "2025-01-26"
+        "citations": 3380,
+        "datestamp": "2025-02-23"
       },
       "Octopus": {
-        "citations": 353,
-        "datestamp": "2025-01-26"
+        "citations": 340,
+        "datestamp": "2025-02-23"
       },
       "OpenMM": {
-        "citations": 1130,
-        "datestamp": "2025-01-26"
+        "citations": 1070,
+        "datestamp": "2025-02-23"
       },
       "OpenMX": {
-        "citations": 160,
-        "datestamp": "2025-01-26"
+        "citations": 166,
+        "datestamp": "2025-02-23"
       },
       "OpenMolcas": {
-        "citations": 206,
-        "datestamp": "2025-01-26"
+        "citations": 191,
+        "datestamp": "2025-02-24"
       },
       "PWmat": {
-        "citations": 125,
-        "datestamp": "2025-01-26"
+        "citations": 127,
+        "datestamp": "2025-02-24"
       },
       "Psi4": {
-        "citations": 256,
-        "datestamp": "2025-01-26"
+        "citations": 235,
+        "datestamp": "2025-02-24"
       },
       "PySCF": {
-        "citations": 488,
-        "datestamp": "2025-01-26"
+        "citations": 458,
+        "datestamp": "2025-02-24"
       },
       "Q-Chem": {
-        "citations": 526,
-        "datestamp": "2025-01-26"
+        "citations": 503,
+        "datestamp": "2025-02-24"
       },
       "QMCPACK": {
-        "citations": 62,
-        "datestamp": "2025-01-26"
+        "citations": 59,
+        "datestamp": "2025-02-24"
       },
       "Quantum ESPRESSO": {
-        "citations": 3870,
-        "datestamp": "2025-01-26"
+        "citations": 3630,
+        "datestamp": "2025-02-24"
       },
       "RASPA": {
-        "citations": 282,
-        "datestamp": "2025-01-26"
+        "citations": 264,
+        "datestamp": "2025-02-24"
       },
       "SIESTA": {
-        "citations": 751,
-        "datestamp": "2025-01-26"
+        "citations": 770,
+        "datestamp": "2025-02-24"
       },
       "TB-LMTO-ASA": {
-        "citations": 44,
-        "datestamp": "2025-01-26"
+        "citations": 43,
+        "datestamp": "2025-02-24"
       },
       "TINKER": {
-        "citations": 360,
-        "datestamp": "2025-01-26"
+        "citations": 352,
+        "datestamp": "2025-02-24"
       },
       "TURBOMOLE": {
-        "citations": 592,
-        "datestamp": "2025-01-26"
+        "citations": 539,
+        "datestamp": "2025-02-24"
       },
       "TeraChem": {
-        "citations": 97,
-        "datestamp": "2025-01-26"
+        "citations": 91,
+        "datestamp": "2025-02-24"
       },
       "VASP": {
-        "citations": 14200,
-        "datestamp": "2025-01-26"
+        "citations": 13700,
+        "datestamp": "2025-02-24"
       },
       "WIEN2k": {
-        "citations": 1750,
-        "datestamp": "2025-01-26"
+        "citations": 1660,
+        "datestamp": "2025-02-24"
       },
       "Wannier90": {
-        "citations": 1010,
-        "datestamp": "2025-01-26"
+        "citations": 924,
+        "datestamp": "2025-02-24"
       },
       "YASARA": {
-        "citations": 492,
-        "datestamp": "2025-01-26"
+        "citations": 465,
+        "datestamp": "2025-02-24"
       },
       "Yambo": {
-        "citations": 151,
-        "datestamp": "2025-01-26"
+        "citations": 138,
+        "datestamp": "2025-02-24"
       },
       "deMon2k": {
-        "citations": 50,
-        "datestamp": "2025-01-26"
+        "citations": 46,
+        "datestamp": "2025-02-23"
       },
       "exciting": {
-        "citations": 62,
-        "datestamp": "2025-01-26"
+        "citations": 55,
+        "datestamp": "2025-02-23"
       },
       "xTB": {
-        "citations": 1220,
-        "datestamp": "2025-01-26"
+        "citations": 1160,
+        "datestamp": "2025-02-24"
       }
     },
     "year_high": 2024,

--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -5002,308 +5002,308 @@
   "2024-2024": {
     "citations": {
       "ABINIT": {
-        "citations": 355,
-        "datestamp": "2025-03-15"
+        "citations": 361,
+        "datestamp": "2025-04-20"
       },
       "ACEMD": {
-        "citations": 65,
-        "datestamp": "2025-03-15"
+        "citations": 60,
+        "datestamp": "2025-04-20"
       },
       "ADF": {
-        "citations": 559,
-        "datestamp": "2025-03-15"
+        "citations": 561,
+        "datestamp": "2025-04-20"
       },
       "ATK/QuantumATK": {
-        "citations": 814,
-        "datestamp": "2025-03-15"
+        "citations": 817,
+        "datestamp": "2025-04-20"
       },
       "Amber": {
-        "citations": 2480,
-        "datestamp": "2025-03-15"
+        "citations": 2500,
+        "datestamp": "2025-04-20"
       },
       "BerkeleyGW": {
-        "citations": 124,
-        "datestamp": "2025-03-15"
+        "citations": 125,
+        "datestamp": "2025-04-20"
       },
       "BoltzTrap": {
-        "citations": 935,
-        "datestamp": "2025-03-15"
+        "citations": 936,
+        "datestamp": "2025-04-20"
       },
       "CASINO": {
-        "citations": 38,
-        "datestamp": "2025-03-15"
+        "citations": 36,
+        "datestamp": "2025-04-20"
       },
       "CASTEP": {
-        "citations": 3110,
-        "datestamp": "2025-03-15"
+        "citations": 3130,
+        "datestamp": "2025-04-20"
       },
       "CFOUR": {
-        "citations": 182,
-        "datestamp": "2025-03-15"
+        "citations": 184,
+        "datestamp": "2025-04-20"
       },
       "CHARMM": {
-        "citations": 898,
-        "datestamp": "2025-03-15"
+        "citations": 907,
+        "datestamp": "2025-04-20"
       },
       "COLUMBUS": {
         "citations": 46,
-        "datestamp": "2025-03-15"
+        "datestamp": "2025-04-20"
       },
       "CP2K": {
-        "citations": 1370,
-        "datestamp": "2025-03-15"
+        "citations": 1380,
+        "datestamp": "2025-04-20"
       },
       "CPMD": {
         "citations": 189,
-        "datestamp": "2025-03-15"
+        "datestamp": "2025-04-20"
       },
       "CRYSTAL": {
-        "citations": 333,
-        "datestamp": "2025-03-15"
+        "citations": 337,
+        "datestamp": "2025-04-20"
       },
       "DFTB+": {
-        "citations": 79,
-        "datestamp": "2025-03-15"
+        "citations": 80,
+        "datestamp": "2025-04-20"
       },
       "DIRAC": {
-        "citations": 181,
-        "datestamp": "2025-03-15"
+        "citations": 167,
+        "datestamp": "2025-04-20"
       },
       "DL_POLY": {
-        "citations": 133,
-        "datestamp": "2025-03-15"
+        "citations": 134,
+        "datestamp": "2025-04-20"
       },
       "DMol3": {
         "citations": 821,
-        "datestamp": "2025-03-15"
+        "datestamp": "2025-04-20"
       },
       "Dalton": {
-        "citations": 430,
-        "datestamp": "2025-03-15"
+        "citations": 433,
+        "datestamp": "2025-04-20"
       },
       "Desmond": {
-        "citations": 2250,
-        "datestamp": "2025-03-15"
+        "citations": 2270,
+        "datestamp": "2025-04-20"
       },
       "Discovery Studio": {
-        "citations": 1010,
-        "datestamp": "2025-03-15"
+        "citations": 1020,
+        "datestamp": "2025-04-20"
       },
       "EPW": {
-        "citations": 266,
-        "datestamp": "2025-03-15"
+        "citations": 268,
+        "datestamp": "2025-04-20"
       },
       "ESPResSo": {
-        "citations": 122,
-        "datestamp": "2025-03-15"
+        "citations": 105,
+        "datestamp": "2025-04-20"
       },
       "Elk": {
         "citations": 70,
-        "datestamp": "2025-03-15"
+        "datestamp": "2025-04-20"
       },
       "FEFF": {
-        "citations": 225,
-        "datestamp": "2025-03-15"
+        "citations": 228,
+        "datestamp": "2025-04-20"
       },
       "FHI-aims": {
-        "citations": 239,
-        "datestamp": "2025-03-15"
+        "citations": 242,
+        "datestamp": "2025-04-20"
       },
       "FLEUR": {
-        "citations": 60,
-        "datestamp": "2025-03-15"
+        "citations": 56,
+        "datestamp": "2025-04-20"
       },
       "FPLO": {
-        "citations": 179,
-        "datestamp": "2025-03-15"
+        "citations": 181,
+        "datestamp": "2025-04-20"
       },
       "Firefly": {
         "citations": 99,
-        "datestamp": "2025-03-15"
+        "datestamp": "2025-04-20"
       },
       "FoldX": {
-        "citations": 325,
-        "datestamp": "2025-03-15"
+        "citations": 324,
+        "datestamp": "2025-04-20"
       },
       "GAMESS": {
-        "citations": 579,
-        "datestamp": "2025-03-15"
+        "citations": 581,
+        "datestamp": "2025-04-20"
       },
       "GPAW": {
-        "citations": 415,
-        "datestamp": "2025-03-15"
+        "citations": 384,
+        "datestamp": "2025-04-20"
       },
       "GPUMD": {
         "citations": 125,
-        "datestamp": "2025-03-15"
+        "datestamp": "2025-04-20"
       },
       "GROMOS": {
-        "citations": 619,
-        "datestamp": "2025-03-15"
+        "citations": 620,
+        "datestamp": "2025-04-20"
       },
       "GULP": {
-        "citations": 216,
-        "datestamp": "2025-03-15"
+        "citations": 218,
+        "datestamp": "2025-04-20"
       },
       "Gaussian": {
-        "citations": 13600,
-        "datestamp": "2025-03-15"
+        "citations": 13900,
+        "datestamp": "2025-04-20"
       },
       "Gromacs": {
-        "citations": 7350,
-        "datestamp": "2025-03-15"
+        "citations": 7410,
+        "datestamp": "2025-04-20"
       },
       "HOOMD-blue": {
-        "citations": 194,
-        "datestamp": "2025-03-15"
+        "citations": 195,
+        "datestamp": "2025-04-20"
       },
       "Hyperchem": {
-        "citations": 222,
-        "datestamp": "2025-03-15"
+        "citations": 223,
+        "datestamp": "2025-04-20"
       },
       "JDFTx": {
-        "citations": 76,
-        "datestamp": "2025-03-15"
+        "citations": 77,
+        "datestamp": "2025-04-20"
       },
       "Jaguar": {
-        "citations": 330,
-        "datestamp": "2025-03-15"
+        "citations": 303,
+        "datestamp": "2025-04-20"
       },
       "LAMMPS": {
-        "citations": 4560,
-        "datestamp": "2025-03-15"
+        "citations": 4590,
+        "datestamp": "2025-04-20"
       },
       "MOE": {
-        "citations": 1050,
-        "datestamp": "2025-03-15"
+        "citations": 1060,
+        "datestamp": "2025-04-20"
       },
       "MOLCAS": {
-        "citations": 164,
-        "datestamp": "2025-03-15"
+        "citations": 166,
+        "datestamp": "2025-04-20"
       },
       "MOPAC": {
-        "citations": 834,
-        "datestamp": "2025-03-15"
+        "citations": 836,
+        "datestamp": "2025-04-20"
       },
       "MacroModel": {
-        "citations": 388,
-        "datestamp": "2025-03-15"
+        "citations": 392,
+        "datestamp": "2025-04-20"
       },
       "Molpro": {
-        "citations": 761,
-        "datestamp": "2025-03-15"
+        "citations": 767,
+        "datestamp": "2025-04-20"
       },
       "NAMD": {
-        "citations": 1440,
-        "datestamp": "2025-03-15"
+        "citations": 1450,
+        "datestamp": "2025-04-20"
       },
       "NWChem": {
-        "citations": 277,
-        "datestamp": "2025-03-15"
+        "citations": 279,
+        "datestamp": "2025-04-20"
       },
       "ONETEP": {
-        "citations": 39,
-        "datestamp": "2025-03-15"
+        "citations": 40,
+        "datestamp": "2025-04-20"
       },
       "ORCA": {
-        "citations": 3400,
-        "datestamp": "2025-03-15"
+        "citations": 3420,
+        "datestamp": "2025-04-20"
       },
       "Octopus": {
-        "citations": 345,
-        "datestamp": "2025-03-15"
+        "citations": 357,
+        "datestamp": "2025-04-20"
       },
       "OpenMM": {
         "citations": 1090,
-        "datestamp": "2025-03-15"
+        "datestamp": "2025-04-20"
       },
       "OpenMX": {
-        "citations": 166,
-        "datestamp": "2025-03-15"
+        "citations": 167,
+        "datestamp": "2025-04-20"
       },
       "OpenMolcas": {
-        "citations": 176,
-        "datestamp": "2025-03-15"
+        "citations": 179,
+        "datestamp": "2025-04-20"
       },
       "PWmat": {
-        "citations": 127,
-        "datestamp": "2025-03-15"
+        "citations": 128,
+        "datestamp": "2025-04-20"
       },
       "Psi4": {
-        "citations": 235,
-        "datestamp": "2025-03-15"
+        "citations": 236,
+        "datestamp": "2025-04-20"
       },
       "PySCF": {
-        "citations": 422,
-        "datestamp": "2025-03-15"
+        "citations": 386,
+        "datestamp": "2025-04-20"
       },
       "Q-Chem": {
-        "citations": 507,
-        "datestamp": "2025-03-15"
+        "citations": 516,
+        "datestamp": "2025-04-20"
       },
       "QMCPACK": {
-        "citations": 59,
-        "datestamp": "2025-03-15"
+        "citations": 55,
+        "datestamp": "2025-04-20"
       },
       "Quantum ESPRESSO": {
-        "citations": 3650,
-        "datestamp": "2025-03-15"
+        "citations": 3390,
+        "datestamp": "2025-04-20"
       },
       "RASPA": {
-        "citations": 263,
-        "datestamp": "2025-03-15"
+        "citations": 266,
+        "datestamp": "2025-04-20"
       },
       "SIESTA": {
-        "citations": 710,
-        "datestamp": "2025-03-15"
+        "citations": 717,
+        "datestamp": "2025-04-20"
       },
       "TB-LMTO-ASA": {
         "citations": 43,
-        "datestamp": "2025-03-15"
+        "datestamp": "2025-04-20"
       },
       "TINKER": {
-        "citations": 356,
-        "datestamp": "2025-03-15"
+        "citations": 365,
+        "datestamp": "2025-04-20"
       },
       "TURBOMOLE": {
-        "citations": 543,
-        "datestamp": "2025-03-15"
+        "citations": 544,
+        "datestamp": "2025-04-20"
       },
       "TeraChem": {
-        "citations": 91,
-        "datestamp": "2025-03-15"
+        "citations": 93,
+        "datestamp": "2025-04-20"
       },
       "VASP": {
-        "citations": 13700,
-        "datestamp": "2025-03-15"
+        "citations": 12700,
+        "datestamp": "2025-04-20"
       },
       "WIEN2k": {
-        "citations": 1670,
-        "datestamp": "2025-03-15"
+        "citations": 1680,
+        "datestamp": "2025-04-20"
       },
       "Wannier90": {
-        "citations": 926,
-        "datestamp": "2025-03-15"
+        "citations": 849,
+        "datestamp": "2025-04-20"
       },
       "YASARA": {
-        "citations": 468,
-        "datestamp": "2025-03-15"
+        "citations": 469,
+        "datestamp": "2025-04-20"
       },
       "Yambo": {
-        "citations": 139,
-        "datestamp": "2025-03-15"
+        "citations": 140,
+        "datestamp": "2025-04-20"
       },
       "deMon2k": {
-        "citations": 48,
-        "datestamp": "2025-03-15"
+        "citations": 45,
+        "datestamp": "2025-04-20"
       },
       "exciting": {
         "citations": 56,
-        "datestamp": "2025-03-15"
+        "datestamp": "2025-04-20"
       },
       "xTB": {
-        "citations": 1160,
-        "datestamp": "2025-03-15"
+        "citations": 1170,
+        "datestamp": "2025-04-20"
       }
     },
     "year_high": 2024,

--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -4206,316 +4206,308 @@
   "2020-2020": {
     "citations": {
       "ABINIT": {
-        "citations": 435,
-        "datestamp": "2021-08-24"
+        "citations": 373,
+        "datestamp": "2025-02-26"
       },
       "ACEMD": {
-        "citations": 74,
-        "datestamp": "2024-03-06"
+        "citations": 66,
+        "datestamp": "2025-02-26"
       },
       "ADF": {
-        "citations": 635,
-        "datestamp": "2021-08-24"
+        "citations": 567,
+        "datestamp": "2025-02-26"
       },
       "ATK/QuantumATK": {
-        "citations": 489,
-        "datestamp": "2021-08-24"
+        "citations": 505,
+        "datestamp": "2025-02-26"
       },
       "Amber": {
-        "citations": 2060,
-        "datestamp": "2021-08-24"
-      },
-      "BOSS": {
-        "citations": 36,
-        "datestamp": "2021-08-26"
+        "citations": 1920,
+        "datestamp": "2025-02-26"
       },
       "BerkeleyGW": {
-        "citations": 88,
-        "datestamp": "2023-01-30"
+        "citations": 90,
+        "datestamp": "2025-02-26"
       },
       "BoltzTrap": {
-        "citations": 508,
-        "datestamp": "2022-03-19"
+        "citations": 472,
+        "datestamp": "2025-02-26"
       },
       "CASINO": {
-        "citations": 37,
-        "datestamp": "2025-01-26"
+        "citations": 36,
+        "datestamp": "2025-02-26"
       },
       "CASTEP": {
-        "citations": 1830,
-        "datestamp": "2021-08-24"
+        "citations": 1810,
+        "datestamp": "2025-02-26"
       },
       "CFOUR": {
-        "citations": 212,
-        "datestamp": "2021-08-24"
+        "citations": 173,
+        "datestamp": "2025-02-26"
       },
       "CHARMM": {
-        "citations": 785,
-        "datestamp": "2021-08-24"
+        "citations": 808,
+        "datestamp": "2025-02-26"
       },
       "COLUMBUS": {
         "citations": 53,
-        "datestamp": "2024-03-09"
+        "datestamp": "2025-02-26"
       },
       "CP2K": {
-        "citations": 755,
-        "datestamp": "2021-08-24"
+        "citations": 706,
+        "datestamp": "2025-02-26"
       },
       "CPMD": {
-        "citations": 241,
-        "datestamp": "2023-01-28"
+        "citations": 234,
+        "datestamp": "2025-02-26"
       },
       "CRYSTAL": {
-        "citations": 480,
-        "datestamp": "2021-08-24"
+        "citations": 467,
+        "datestamp": "2025-02-26"
       },
       "DFTB+": {
-        "citations": 193,
-        "datestamp": "2021-08-24"
+        "citations": 197,
+        "datestamp": "2025-02-26"
       },
       "DIRAC": {
-        "citations": 180,
-        "datestamp": "2021-08-24"
+        "citations": 148,
+        "datestamp": "2025-02-26"
       },
       "DL_POLY": {
-        "citations": 157,
-        "datestamp": "2021-08-24"
+        "citations": 159,
+        "datestamp": "2025-02-26"
       },
       "DMol3": {
-        "citations": 696,
-        "datestamp": "2021-08-24"
+        "citations": 713,
+        "datestamp": "2025-02-26"
       },
       "Dalton": {
-        "citations": 417,
-        "datestamp": "2021-08-24"
+        "citations": 394,
+        "datestamp": "2025-02-26"
       },
       "Desmond": {
-        "citations": 844,
-        "datestamp": "2021-08-24"
+        "citations": 781,
+        "datestamp": "2025-02-26"
       },
       "Discovery Studio": {
-        "citations": 1050,
-        "datestamp": "2021-08-24"
+        "citations": 992,
+        "datestamp": "2025-02-26"
       },
       "EPW": {
-        "citations": 122,
-        "datestamp": "2021-08-24"
+        "citations": 126,
+        "datestamp": "2025-02-26"
       },
       "ESPResSo": {
-        "citations": 88,
-        "datestamp": "2021-08-24"
+        "citations": 81,
+        "datestamp": "2025-02-26"
       },
       "Elk": {
-        "citations": 116,
-        "datestamp": "2021-08-24"
+        "citations": 109,
+        "datestamp": "2025-02-26"
       },
       "FEFF": {
-        "citations": 306,
-        "datestamp": "2021-08-24"
+        "citations": 274,
+        "datestamp": "2025-02-26"
       },
       "FHI-aims": {
-        "citations": 218,
-        "datestamp": "2021-08-24"
+        "citations": 208,
+        "datestamp": "2025-02-26"
       },
       "FLEUR": {
-        "citations": 42,
-        "datestamp": "2024-03-06"
+        "citations": 40,
+        "datestamp": "2025-02-26"
       },
       "FPLO": {
-        "citations": 129,
-        "datestamp": "2021-08-24"
+        "citations": 115,
+        "datestamp": "2025-02-26"
       },
       "Firefly": {
-        "citations": 172,
-        "datestamp": "2021-08-24"
+        "citations": 173,
+        "datestamp": "2025-02-26"
       },
       "FoldX": {
-        "citations": 242,
-        "datestamp": "2021-08-24"
+        "citations": 231,
+        "datestamp": "2025-02-26"
       },
       "GAMESS": {
-        "citations": 881,
-        "datestamp": "2021-08-24"
+        "citations": 818,
+        "datestamp": "2025-02-26"
       },
       "GPAW": {
-        "citations": 215,
-        "datestamp": "2021-08-24"
+        "citations": 374,
+        "datestamp": "2025-02-26"
       },
       "GPUMD": {
         "citations": 8,
-        "datestamp": "2024-08-25"
+        "datestamp": "2025-02-26"
       },
       "GROMOS": {
-        "citations": 699,
-        "datestamp": "2023-02-28"
+        "citations": 625,
+        "datestamp": "2025-02-26"
       },
       "GULP": {
-        "citations": 193,
-        "datestamp": "2021-08-26"
+        "citations": 202,
+        "datestamp": "2025-02-26"
       },
       "Gaussian": {
-        "citations": 12800,
-        "datestamp": "2022-02-03"
+        "citations": 11900,
+        "datestamp": "2025-02-26"
       },
       "Gromacs": {
-        "citations": 4630,
-        "datestamp": "2021-08-24"
+        "citations": 4190,
+        "datestamp": "2025-02-26"
       },
       "HOOMD-blue": {
-        "citations": 131,
-        "datestamp": "2021-08-24"
+        "citations": 119,
+        "datestamp": "2025-02-26"
       },
       "Hyperchem": {
-        "citations": 314,
-        "datestamp": "2021-08-24"
+        "citations": 281,
+        "datestamp": "2025-02-26"
       },
       "JDFTx": {
         "citations": 48,
-        "datestamp": "2024-03-06"
+        "datestamp": "2025-02-26"
       },
       "Jaguar": {
-        "citations": 297,
-        "datestamp": "2024-03-06"
+        "citations": 277,
+        "datestamp": "2025-02-26"
       },
       "LAMMPS": {
-        "citations": 4130,
-        "datestamp": "2024-03-29"
+        "citations": 3640,
+        "datestamp": "2025-02-26"
       },
       "MOE": {
-        "citations": 1050,
-        "datestamp": "2021-08-24"
+        "citations": 915,
+        "datestamp": "2025-02-26"
       },
       "MOLCAS": {
-        "citations": 294,
-        "datestamp": "2022-03-20"
+        "citations": 255,
+        "datestamp": "2025-02-26"
       },
       "MOPAC": {
-        "citations": 931,
-        "datestamp": "2022-04-15"
+        "citations": 927,
+        "datestamp": "2025-02-26"
       },
       "MacroModel": {
-        "citations": 430,
-        "datestamp": "2021-08-24"
+        "citations": 477,
+        "datestamp": "2025-02-26"
       },
       "Molpro": {
-        "citations": 819,
-        "datestamp": "2021-08-24"
+        "citations": 732,
+        "datestamp": "2025-02-26"
       },
       "NAMD": {
-        "citations": 1370,
-        "datestamp": "2024-03-29"
+        "citations": 1270,
+        "datestamp": "2025-02-26"
       },
       "NWChem": {
-        "citations": 384,
-        "datestamp": "2021-08-31"
+        "citations": 345,
+        "datestamp": "2025-02-26"
       },
       "ONETEP": {
         "citations": 53,
-        "datestamp": "2024-03-09"
+        "datestamp": "2025-02-26"
       },
       "ORCA": {
-        "citations": 1560,
-        "datestamp": "2021-08-24"
+        "citations": 1500,
+        "datestamp": "2025-02-26"
       },
       "Octopus": {
-        "citations": 279,
-        "datestamp": "2021-08-24"
+        "citations": 287,
+        "datestamp": "2025-02-26"
       },
       "OpenMM": {
-        "citations": 452,
-        "datestamp": "2021-08-24"
+        "citations": 415,
+        "datestamp": "2025-02-26"
       },
       "OpenMX": {
-        "citations": 161,
-        "datestamp": "2021-08-24"
+        "citations": 156,
+        "datestamp": "2025-02-26"
       },
       "OpenMolcas": {
-        "citations": 102,
-        "datestamp": "2022-03-20"
+        "citations": 99,
+        "datestamp": "2025-02-26"
       },
       "PWmat": {
-        "citations": 43,
-        "datestamp": "2024-03-06"
+        "citations": 44,
+        "datestamp": "2025-02-26"
       },
       "Psi4": {
-        "citations": 233,
-        "datestamp": "2021-08-24"
+        "citations": 215,
+        "datestamp": "2025-02-26"
       },
       "PySCF": {
-        "citations": 170,
-        "datestamp": "2021-08-24"
+        "citations": 157,
+        "datestamp": "2025-02-26"
       },
       "Q-Chem": {
         "citations": 565,
-        "datestamp": "2021-08-24"
+        "datestamp": "2025-02-26"
       },
       "QMCPACK": {
-        "citations": 70,
-        "datestamp": "2024-03-09"
+        "citations": 68,
+        "datestamp": "2025-02-26"
       },
       "Quantum ESPRESSO": {
-        "citations": 2540,
-        "datestamp": "2021-08-24"
+        "citations": 2400,
+        "datestamp": "2025-02-26"
       },
       "RASPA": {
-        "citations": 160,
-        "datestamp": "2021-08-24"
+        "citations": 150,
+        "datestamp": "2025-02-26"
       },
       "SIESTA": {
-        "citations": 864,
-        "datestamp": "2021-08-24"
+        "citations": 822,
+        "datestamp": "2025-02-26"
       },
       "TB-LMTO-ASA": {
-        "citations": 84,
-        "datestamp": "2021-08-24"
+        "citations": 90,
+        "datestamp": "2025-02-26"
       },
       "TINKER": {
-        "citations": 415,
-        "datestamp": "2023-01-28"
+        "citations": 396,
+        "datestamp": "2025-02-26"
       },
       "TURBOMOLE": {
-        "citations": 595,
-        "datestamp": "2021-08-24"
+        "citations": 521,
+        "datestamp": "2025-02-26"
       },
       "TeraChem": {
-        "citations": 83,
-        "datestamp": "2022-01-10"
+        "citations": 77,
+        "datestamp": "2025-02-26"
       },
       "VASP": {
-        "citations": 9480,
-        "datestamp": "2024-03-29"
-      },
-      "WHAT IF": {
-        "citations": 128,
-        "datestamp": "2021-08-24"
+        "citations": 8620,
+        "datestamp": "2025-02-26"
       },
       "WIEN2k": {
-        "citations": 1330,
-        "datestamp": "2021-08-24"
+        "citations": 1280,
+        "datestamp": "2025-02-26"
       },
       "Wannier90": {
-        "citations": 428,
-        "datestamp": "2021-08-24"
+        "citations": 414,
+        "datestamp": "2025-02-26"
       },
       "YASARA": {
-        "citations": 490,
-        "datestamp": "2021-08-24"
+        "citations": 438,
+        "datestamp": "2025-02-26"
       },
       "Yambo": {
-        "citations": 100,
-        "datestamp": "2021-08-24"
+        "citations": 98,
+        "datestamp": "2025-03-02"
       },
       "deMon2k": {
         "citations": 44,
-        "datestamp": "2024-03-06"
+        "datestamp": "2025-02-26"
       },
       "exciting": {
-        "citations": 50,
-        "datestamp": "2024-03-06"
+        "citations": 47,
+        "datestamp": "2025-02-26"
       },
       "xTB": {
-        "citations": 267,
-        "datestamp": "2021-08-24"
+        "citations": 262,
+        "datestamp": "2025-03-02"
       }
     },
     "year_high": 2020,

--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -5149,6 +5149,316 @@
     "year_high": 2022,
     "year_low": 2022
   },
+  "2022-2022": {
+    "citations": {
+      "ABINIT": {
+        "citations": 326,
+        "datestamp": "2025-02-26"
+      },
+      "ACEMD": {
+        "citations": 59,
+        "datestamp": "2025-02-26"
+      },
+      "ADF": {
+        "citations": 565,
+        "datestamp": "2025-02-26"
+      },
+      "ATK/QuantumATK": {
+        "citations": 695,
+        "datestamp": "2025-02-26"
+      },
+      "Amber": {
+        "citations": 2510,
+        "datestamp": "2025-02-26"
+      },
+      "BerkeleyGW": {
+        "citations": 108,
+        "datestamp": "2025-02-26"
+      },
+      "BoltzTrap": {
+        "citations": 688,
+        "datestamp": "2025-02-26"
+      },
+      "CASINO": {
+        "citations": 39,
+        "datestamp": "2025-02-26"
+      },
+      "CASTEP": {
+        "citations": 2560,
+        "datestamp": "2025-02-26"
+      },
+      "CFOUR": {
+        "citations": 173,
+        "datestamp": "2025-02-26"
+      },
+      "CHARMM": {
+        "citations": 848,
+        "datestamp": "2025-02-26"
+      },
+      "COLUMBUS": {
+        "citations": 51,
+        "datestamp": "2025-02-26"
+      },
+      "CP2K": {
+        "citations": 835,
+        "datestamp": "2025-02-26"
+      },
+      "CPMD": {
+        "citations": 227,
+        "datestamp": "2025-02-26"
+      },
+      "CRYSTAL": {
+        "citations": 399,
+        "datestamp": "2025-02-26"
+      },
+      "DFTB+": {
+        "citations": 128,
+        "datestamp": "2025-02-26"
+      },
+      "DIRAC": {
+        "citations": 170,
+        "datestamp": "2025-02-26"
+      },
+      "DL_POLY": {
+        "citations": 179,
+        "datestamp": "2025-02-26"
+      },
+      "DMol3": {
+        "citations": 866,
+        "datestamp": "2025-02-26"
+      },
+      "Dalton": {
+        "citations": 497,
+        "datestamp": "2025-02-26"
+      },
+      "Desmond": {
+        "citations": 1510,
+        "datestamp": "2025-02-26"
+      },
+      "Discovery Studio": {
+        "citations": 1160,
+        "datestamp": "2025-02-26"
+      },
+      "EPW": {
+        "citations": 177,
+        "datestamp": "2025-02-26"
+      },
+      "ESPResSo": {
+        "citations": 75,
+        "datestamp": "2025-02-26"
+      },
+      "Elk": {
+        "citations": 107,
+        "datestamp": "2025-02-26"
+      },
+      "FEFF": {
+        "citations": 267,
+        "datestamp": "2025-02-26"
+      },
+      "FHI-aims": {
+        "citations": 230,
+        "datestamp": "2025-02-26"
+      },
+      "FLEUR": {
+        "citations": 46,
+        "datestamp": "2025-02-26"
+      },
+      "FPLO": {
+        "citations": 98,
+        "datestamp": "2025-02-26"
+      },
+      "Firefly": {
+        "citations": 145,
+        "datestamp": "2025-02-26"
+      },
+      "FoldX": {
+        "citations": 283,
+        "datestamp": "2025-02-26"
+      },
+      "GAMESS": {
+        "citations": 737,
+        "datestamp": "2025-02-26"
+      },
+      "GPAW": {
+        "citations": 361,
+        "datestamp": "2025-02-26"
+      },
+      "GPUMD": {
+        "citations": 33,
+        "datestamp": "2025-02-26"
+      },
+      "GROMOS": {
+        "citations": 695,
+        "datestamp": "2025-02-26"
+      },
+      "GULP": {
+        "citations": 208,
+        "datestamp": "2025-02-26"
+      },
+      "Gaussian": {
+        "citations": 13800,
+        "datestamp": "2025-02-26"
+      },
+      "Gromacs": {
+        "citations": 5850,
+        "datestamp": "2025-02-26"
+      },
+      "HOOMD-blue": {
+        "citations": 135,
+        "datestamp": "2025-02-26"
+      },
+      "Hyperchem": {
+        "citations": 284,
+        "datestamp": "2025-02-26"
+      },
+      "JDFTx": {
+        "citations": 68,
+        "datestamp": "2025-02-26"
+      },
+      "Jaguar": {
+        "citations": 310,
+        "datestamp": "2025-02-26"
+      },
+      "LAMMPS": {
+        "citations": 4380,
+        "datestamp": "2025-02-26"
+      },
+      "MOE": {
+        "citations": 1160,
+        "datestamp": "2025-02-26"
+      },
+      "MOLCAS": {
+        "citations": 212,
+        "datestamp": "2025-02-26"
+      },
+      "MOPAC": {
+        "citations": 924,
+        "datestamp": "2025-02-26"
+      },
+      "MacroModel": {
+        "citations": 499,
+        "datestamp": "2025-02-26"
+      },
+      "Molpro": {
+        "citations": 741,
+        "datestamp": "2025-02-26"
+      },
+      "NAMD": {
+        "citations": 1470,
+        "datestamp": "2025-02-26"
+      },
+      "NWChem": {
+        "citations": 291,
+        "datestamp": "2025-02-26"
+      },
+      "ONETEP": {
+        "citations": 47,
+        "datestamp": "2025-02-26"
+      },
+      "ORCA": {
+        "citations": 2270,
+        "datestamp": "2025-02-26"
+      },
+      "Octopus": {
+        "citations": 346,
+        "datestamp": "2025-02-26"
+      },
+      "OpenMM": {
+        "citations": 667,
+        "datestamp": "2025-02-26"
+      },
+      "OpenMX": {
+        "citations": 147,
+        "datestamp": "2025-02-26"
+      },
+      "OpenMolcas": {
+        "citations": 168,
+        "datestamp": "2025-02-26"
+      },
+      "PWmat": {
+        "citations": 81,
+        "datestamp": "2025-02-26"
+      },
+      "Psi4": {
+        "citations": 244,
+        "datestamp": "2025-02-26"
+      },
+      "PySCF": {
+        "citations": 227,
+        "datestamp": "2025-02-26"
+      },
+      "Q-Chem": {
+        "citations": 488,
+        "datestamp": "2025-02-26"
+      },
+      "QMCPACK": {
+        "citations": 46,
+        "datestamp": "2025-02-26"
+      },
+      "Quantum ESPRESSO": {
+        "citations": 3070,
+        "datestamp": "2025-02-26"
+      },
+      "RASPA": {
+        "citations": 213,
+        "datestamp": "2025-02-26"
+      },
+      "SIESTA": {
+        "citations": 837,
+        "datestamp": "2025-02-26"
+      },
+      "TB-LMTO-ASA": {
+        "citations": 62,
+        "datestamp": "2025-02-26"
+      },
+      "TINKER": {
+        "citations": 393,
+        "datestamp": "2025-02-26"
+      },
+      "TURBOMOLE": {
+        "citations": 510,
+        "datestamp": "2025-02-26"
+      },
+      "TeraChem": {
+        "citations": 95,
+        "datestamp": "2025-02-26"
+      },
+      "VASP": {
+        "citations": 11500,
+        "datestamp": "2025-02-26"
+      },
+      "WIEN2k": {
+        "citations": 1340,
+        "datestamp": "2025-02-26"
+      },
+      "Wannier90": {
+        "citations": 593,
+        "datestamp": "2025-02-26"
+      },
+      "YASARA": {
+        "citations": 488,
+        "datestamp": "2025-02-26"
+      },
+      "Yambo": {
+        "citations": 110,
+        "datestamp": "2025-02-26"
+      },
+      "deMon2k": {
+        "citations": 69,
+        "datestamp": "2025-02-26"
+      },
+      "exciting": {
+        "citations": 59,
+        "datestamp": "2025-02-26"
+      },
+      "xTB": {
+        "citations": 672,
+        "datestamp": "2025-02-26"
+      }
+    },
+    "year_high": 2022,
+    "year_low": 2022
+  },
   "2023-2023": {
     "citations": {
       "ABINIT": {

--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -5002,308 +5002,308 @@
   "2024-2024": {
     "citations": {
       "ABINIT": {
-        "citations": 349,
-        "datestamp": "2025-02-23"
+        "citations": 355,
+        "datestamp": "2025-03-15"
       },
       "ACEMD": {
-        "citations": 64,
-        "datestamp": "2025-02-23"
+        "citations": 65,
+        "datestamp": "2025-03-15"
       },
       "ADF": {
-        "citations": 556,
-        "datestamp": "2025-02-23"
+        "citations": 559,
+        "datestamp": "2025-03-15"
       },
       "ATK/QuantumATK": {
-        "citations": 806,
-        "datestamp": "2025-02-23"
+        "citations": 814,
+        "datestamp": "2025-03-15"
       },
       "Amber": {
-        "citations": 2450,
-        "datestamp": "2025-02-23"
+        "citations": 2480,
+        "datestamp": "2025-03-15"
       },
       "BerkeleyGW": {
         "citations": 124,
-        "datestamp": "2025-02-23"
+        "datestamp": "2025-03-15"
       },
       "BoltzTrap": {
-        "citations": 929,
-        "datestamp": "2025-02-23"
+        "citations": 935,
+        "datestamp": "2025-03-15"
       },
       "CASINO": {
         "citations": 38,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-15"
       },
       "CASTEP": {
         "citations": 3110,
-        "datestamp": "2025-02-23"
+        "datestamp": "2025-03-15"
       },
       "CFOUR": {
         "citations": 182,
-        "datestamp": "2025-02-23"
+        "datestamp": "2025-03-15"
       },
       "CHARMM": {
-        "citations": 891,
-        "datestamp": "2025-02-23"
+        "citations": 898,
+        "datestamp": "2025-03-15"
       },
       "COLUMBUS": {
         "citations": 46,
-        "datestamp": "2025-02-23"
+        "datestamp": "2025-03-15"
       },
       "CP2K": {
-        "citations": 1360,
-        "datestamp": "2025-02-23"
+        "citations": 1370,
+        "datestamp": "2025-03-15"
       },
       "CPMD": {
-        "citations": 187,
-        "datestamp": "2025-02-23"
+        "citations": 189,
+        "datestamp": "2025-03-15"
       },
       "CRYSTAL": {
-        "citations": 329,
-        "datestamp": "2025-02-23"
+        "citations": 333,
+        "datestamp": "2025-03-15"
       },
       "DFTB+": {
         "citations": 79,
-        "datestamp": "2025-02-23"
+        "datestamp": "2025-03-15"
       },
       "DIRAC": {
-        "citations": 180,
-        "datestamp": "2025-02-23"
+        "citations": 181,
+        "datestamp": "2025-03-15"
       },
       "DL_POLY": {
         "citations": 133,
-        "datestamp": "2025-02-23"
+        "datestamp": "2025-03-15"
       },
       "DMol3": {
-        "citations": 819,
-        "datestamp": "2025-02-23"
+        "citations": 821,
+        "datestamp": "2025-03-15"
       },
       "Dalton": {
-        "citations": 428,
-        "datestamp": "2025-02-23"
+        "citations": 430,
+        "datestamp": "2025-03-15"
       },
       "Desmond": {
-        "citations": 2230,
-        "datestamp": "2025-02-23"
+        "citations": 2250,
+        "datestamp": "2025-03-15"
       },
       "Discovery Studio": {
         "citations": 1010,
-        "datestamp": "2025-02-23"
+        "datestamp": "2025-03-15"
       },
       "EPW": {
         "citations": 266,
-        "datestamp": "2025-02-23"
+        "datestamp": "2025-03-15"
       },
       "ESPResSo": {
-        "citations": 111,
-        "datestamp": "2025-02-23"
+        "citations": 122,
+        "datestamp": "2025-03-15"
       },
       "Elk": {
         "citations": 70,
-        "datestamp": "2025-02-23"
+        "datestamp": "2025-03-15"
       },
       "FEFF": {
-        "citations": 222,
-        "datestamp": "2025-02-23"
+        "citations": 225,
+        "datestamp": "2025-03-15"
       },
       "FHI-aims": {
-        "citations": 259,
-        "datestamp": "2025-02-23"
+        "citations": 239,
+        "datestamp": "2025-03-15"
       },
       "FLEUR": {
         "citations": 60,
-        "datestamp": "2025-02-23"
+        "datestamp": "2025-03-15"
       },
       "FPLO": {
-        "citations": 177,
-        "datestamp": "2025-02-23"
+        "citations": 179,
+        "datestamp": "2025-03-15"
       },
       "Firefly": {
-        "citations": 97,
-        "datestamp": "2025-02-23"
+        "citations": 99,
+        "datestamp": "2025-03-15"
       },
       "FoldX": {
-        "citations": 320,
-        "datestamp": "2025-02-23"
+        "citations": 325,
+        "datestamp": "2025-03-15"
       },
       "GAMESS": {
-        "citations": 578,
-        "datestamp": "2025-02-23"
+        "citations": 579,
+        "datestamp": "2025-03-15"
       },
       "GPAW": {
-        "citations": 413,
-        "datestamp": "2025-02-23"
+        "citations": 415,
+        "datestamp": "2025-03-15"
       },
       "GPUMD": {
         "citations": 125,
-        "datestamp": "2025-02-23"
+        "datestamp": "2025-03-15"
       },
       "GROMOS": {
-        "citations": 613,
-        "datestamp": "2025-02-23"
+        "citations": 619,
+        "datestamp": "2025-03-15"
       },
       "GULP": {
-        "citations": 210,
-        "datestamp": "2025-02-23"
+        "citations": 216,
+        "datestamp": "2025-03-15"
       },
       "Gaussian": {
-        "citations": 13700,
-        "datestamp": "2025-02-23"
+        "citations": 13600,
+        "datestamp": "2025-03-15"
       },
       "Gromacs": {
-        "citations": 7260,
-        "datestamp": "2025-02-23"
+        "citations": 7350,
+        "datestamp": "2025-03-15"
       },
       "HOOMD-blue": {
-        "citations": 192,
-        "datestamp": "2025-02-23"
+        "citations": 194,
+        "datestamp": "2025-03-15"
       },
       "Hyperchem": {
-        "citations": 219,
-        "datestamp": "2025-02-23"
+        "citations": 222,
+        "datestamp": "2025-03-15"
       },
       "JDFTx": {
-        "citations": 83,
-        "datestamp": "2025-02-23"
+        "citations": 76,
+        "datestamp": "2025-03-15"
       },
       "Jaguar": {
-        "citations": 331,
-        "datestamp": "2025-02-23"
+        "citations": 330,
+        "datestamp": "2025-03-15"
       },
       "LAMMPS": {
-        "citations": 4530,
-        "datestamp": "2025-02-23"
+        "citations": 4560,
+        "datestamp": "2025-03-15"
       },
       "MOE": {
-        "citations": 1040,
-        "datestamp": "2025-02-23"
+        "citations": 1050,
+        "datestamp": "2025-03-15"
       },
       "MOLCAS": {
-        "citations": 179,
-        "datestamp": "2025-02-23"
+        "citations": 164,
+        "datestamp": "2025-03-15"
       },
       "MOPAC": {
-        "citations": 828,
-        "datestamp": "2025-02-23"
+        "citations": 834,
+        "datestamp": "2025-03-15"
       },
       "MacroModel": {
-        "citations": 387,
-        "datestamp": "2025-02-23"
+        "citations": 388,
+        "datestamp": "2025-03-15"
       },
       "Molpro": {
-        "citations": 759,
-        "datestamp": "2025-02-23"
+        "citations": 761,
+        "datestamp": "2025-03-15"
       },
       "NAMD": {
-        "citations": 1430,
-        "datestamp": "2025-02-23"
+        "citations": 1440,
+        "datestamp": "2025-03-15"
       },
       "NWChem": {
-        "citations": 275,
-        "datestamp": "2025-02-23"
+        "citations": 277,
+        "datestamp": "2025-03-15"
       },
       "ONETEP": {
         "citations": 39,
-        "datestamp": "2025-02-23"
+        "datestamp": "2025-03-15"
       },
       "ORCA": {
-        "citations": 3380,
-        "datestamp": "2025-02-23"
+        "citations": 3400,
+        "datestamp": "2025-03-15"
       },
       "Octopus": {
-        "citations": 340,
-        "datestamp": "2025-02-23"
+        "citations": 345,
+        "datestamp": "2025-03-15"
       },
       "OpenMM": {
-        "citations": 1070,
-        "datestamp": "2025-02-23"
+        "citations": 1090,
+        "datestamp": "2025-03-15"
       },
       "OpenMX": {
         "citations": 166,
-        "datestamp": "2025-02-23"
+        "datestamp": "2025-03-15"
       },
       "OpenMolcas": {
-        "citations": 191,
-        "datestamp": "2025-02-24"
+        "citations": 176,
+        "datestamp": "2025-03-15"
       },
       "PWmat": {
         "citations": 127,
-        "datestamp": "2025-02-24"
+        "datestamp": "2025-03-15"
       },
       "Psi4": {
         "citations": 235,
-        "datestamp": "2025-02-24"
+        "datestamp": "2025-03-15"
       },
       "PySCF": {
-        "citations": 458,
-        "datestamp": "2025-02-24"
+        "citations": 422,
+        "datestamp": "2025-03-15"
       },
       "Q-Chem": {
-        "citations": 503,
-        "datestamp": "2025-02-24"
+        "citations": 507,
+        "datestamp": "2025-03-15"
       },
       "QMCPACK": {
         "citations": 59,
-        "datestamp": "2025-02-24"
+        "datestamp": "2025-03-15"
       },
       "Quantum ESPRESSO": {
-        "citations": 3630,
-        "datestamp": "2025-02-24"
+        "citations": 3650,
+        "datestamp": "2025-03-15"
       },
       "RASPA": {
-        "citations": 264,
-        "datestamp": "2025-02-24"
+        "citations": 263,
+        "datestamp": "2025-03-15"
       },
       "SIESTA": {
-        "citations": 770,
-        "datestamp": "2025-02-24"
+        "citations": 710,
+        "datestamp": "2025-03-15"
       },
       "TB-LMTO-ASA": {
         "citations": 43,
-        "datestamp": "2025-02-24"
+        "datestamp": "2025-03-15"
       },
       "TINKER": {
-        "citations": 352,
-        "datestamp": "2025-02-24"
+        "citations": 356,
+        "datestamp": "2025-03-15"
       },
       "TURBOMOLE": {
-        "citations": 539,
-        "datestamp": "2025-02-24"
+        "citations": 543,
+        "datestamp": "2025-03-15"
       },
       "TeraChem": {
         "citations": 91,
-        "datestamp": "2025-02-24"
+        "datestamp": "2025-03-15"
       },
       "VASP": {
         "citations": 13700,
-        "datestamp": "2025-02-24"
+        "datestamp": "2025-03-15"
       },
       "WIEN2k": {
-        "citations": 1660,
-        "datestamp": "2025-02-24"
+        "citations": 1670,
+        "datestamp": "2025-03-15"
       },
       "Wannier90": {
-        "citations": 924,
-        "datestamp": "2025-02-24"
+        "citations": 926,
+        "datestamp": "2025-03-15"
       },
       "YASARA": {
-        "citations": 465,
-        "datestamp": "2025-02-24"
+        "citations": 468,
+        "datestamp": "2025-03-15"
       },
       "Yambo": {
-        "citations": 138,
-        "datestamp": "2025-02-24"
+        "citations": 139,
+        "datestamp": "2025-03-15"
       },
       "deMon2k": {
-        "citations": 46,
-        "datestamp": "2025-02-23"
+        "citations": 48,
+        "datestamp": "2025-03-15"
       },
       "exciting": {
-        "citations": 55,
-        "datestamp": "2025-02-23"
+        "citations": 56,
+        "datestamp": "2025-03-15"
       },
       "xTB": {
         "citations": 1160,
-        "datestamp": "2025-02-24"
+        "datestamp": "2025-03-15"
       }
     },
     "year_high": 2024,

--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -4524,312 +4524,308 @@
   "2021-2021": {
     "citations": {
       "ABINIT": {
-        "citations": 376,
-        "datestamp": "2024-03-29"
+        "citations": 343,
+        "datestamp": "2025-02-26"
       },
       "ACEMD": {
-        "citations": 72,
-        "datestamp": "2024-03-29"
+        "citations": 67,
+        "datestamp": "2025-02-26"
       },
       "ADF": {
-        "citations": 648,
-        "datestamp": "2024-03-29"
+        "citations": 577,
+        "datestamp": "2025-02-26"
       },
       "ATK/QuantumATK": {
-        "citations": 603,
-        "datestamp": "2024-03-29"
+        "citations": 581,
+        "datestamp": "2025-02-26"
       },
       "Amber": {
-        "citations": 2430,
-        "datestamp": "2024-03-29"
+        "citations": 2060,
+        "datestamp": "2025-02-26"
       },
       "BerkeleyGW": {
-        "citations": 107,
-        "datestamp": "2024-03-29"
+        "citations": 101,
+        "datestamp": "2025-02-26"
       },
       "BoltzTrap": {
-        "citations": 664,
-        "datestamp": "2024-03-29"
+        "citations": 586,
+        "datestamp": "2025-02-26"
       },
       "CASINO": {
-        "citations": 31,
-        "datestamp": "2025-01-26"
+        "citations": 29,
+        "datestamp": "2025-02-26"
       },
       "CASTEP": {
-        "citations": 2400,
-        "datestamp": "2024-03-29"
+        "citations": 2180,
+        "datestamp": "2025-02-26"
       },
       "CFOUR": {
-        "citations": 173,
-        "datestamp": "2024-03-29"
+        "citations": 165,
+        "datestamp": "2025-02-26"
       },
       "CHARMM": {
-        "citations": 957,
-        "datestamp": "2024-03-29"
+        "citations": 882,
+        "datestamp": "2025-02-26"
       },
       "COLUMBUS": {
-        "citations": 55,
-        "datestamp": "2024-03-29"
+        "citations": 53,
+        "datestamp": "2025-02-26"
       },
       "CP2K": {
-        "citations": 812,
-        "datestamp": "2024-03-29"
+        "citations": 761,
+        "datestamp": "2025-02-26"
       },
       "CPMD": {
-        "citations": 234,
-        "datestamp": "2024-03-29"
+        "citations": 216,
+        "datestamp": "2025-02-26"
       },
       "CRYSTAL": {
-        "citations": 385,
-        "datestamp": "2024-03-29"
+        "citations": 367,
+        "datestamp": "2025-02-26"
       },
       "DFTB+": {
-        "citations": 162,
-        "datestamp": "2024-03-29"
+        "citations": 164,
+        "datestamp": "2025-02-26"
       },
       "DIRAC": {
-        "citations": 153,
-        "datestamp": "2024-03-29"
+        "citations": 147,
+        "datestamp": "2025-02-26"
       },
       "DL_POLY": {
-        "citations": 180,
-        "datestamp": "2024-03-29"
+        "citations": 159,
+        "datestamp": "2025-02-26"
       },
       "DMol3": {
-        "citations": 880,
-        "datestamp": "2024-03-29"
+        "citations": 706,
+        "datestamp": "2025-02-26"
       },
       "Dalton": {
-        "citations": 468,
-        "datestamp": "2024-03-29"
+        "citations": 431,
+        "datestamp": "2025-02-26"
       },
       "Desmond": {
-        "citations": 1090,
-        "datestamp": "2024-03-29"
+        "citations": 1080,
+        "datestamp": "2025-02-26"
       },
       "Discovery Studio": {
-        "citations": 1220,
-        "datestamp": "2024-03-29"
+        "citations": 1150,
+        "datestamp": "2025-02-26"
       },
       "EPW": {
-        "citations": 150,
-        "datestamp": "2024-03-29"
+        "citations": 141,
+        "datestamp": "2025-02-26"
       },
       "ESPResSo": {
-        "citations": 108,
-        "datestamp": "2024-03-29"
+        "citations": 99,
+        "datestamp": "2025-02-26"
       },
       "Elk": {
-        "citations": 98,
-        "datestamp": "2024-03-29"
+        "citations": 91,
+        "datestamp": "2025-02-26"
       },
       "FEFF": {
-        "citations": 312,
-        "datestamp": "2024-03-29"
+        "citations": 270,
+        "datestamp": "2025-02-26"
       },
       "FHI-aims": {
-        "citations": 230,
-        "datestamp": "2024-03-29"
+        "citations": 228,
+        "datestamp": "2025-02-26"
       },
       "FLEUR": {
         "citations": 38,
-        "datestamp": "2024-03-29"
+        "datestamp": "2025-02-26"
       },
       "FPLO": {
-        "citations": 118,
-        "datestamp": "2024-03-29"
+        "citations": 120,
+        "datestamp": "2025-02-26"
       },
       "Firefly": {
-        "citations": 151,
-        "datestamp": "2024-03-29"
+        "citations": 145,
+        "datestamp": "2025-02-26"
       },
       "FoldX": {
-        "citations": 310,
-        "datestamp": "2024-03-29"
+        "citations": 302,
+        "datestamp": "2025-02-26"
       },
       "GAMESS": {
-        "citations": 839,
-        "datestamp": "2024-03-29"
+        "citations": 769,
+        "datestamp": "2025-02-26"
       },
       "GPAW": {
-        "citations": 205,
-        "datestamp": "2024-03-29"
+        "citations": 340,
+        "datestamp": "2025-02-26"
       },
       "GPUMD": {
-        "citations": 26,
-        "datestamp": "2024-08-25"
+        "citations": 22,
+        "datestamp": "2025-02-26"
       },
       "GROMOS": {
-        "citations": 750,
-        "datestamp": "2024-03-29"
+        "citations": 654,
+        "datestamp": "2025-02-26"
       },
       "GULP": {
-        "citations": 257,
-        "datestamp": "2024-03-29"
+        "citations": 231,
+        "datestamp": "2025-02-26"
       },
       "Gaussian": {
-        "citations": 13800,
-        "datestamp": "2024-03-29"
+        "citations": 12600,
+        "datestamp": "2025-02-26"
       },
       "Gromacs": {
-        "citations": 5320,
-        "datestamp": "2024-03-29"
+        "citations": 4960,
+        "datestamp": "2025-02-26"
       },
       "HOOMD-blue": {
-        "citations": 139,
-        "datestamp": "2024-03-29"
+        "citations": 135,
+        "datestamp": "2025-02-26"
       },
       "Hyperchem": {
-        "citations": 324,
-        "datestamp": "2024-03-29"
+        "citations": 308,
+        "datestamp": "2025-02-26"
       },
       "JDFTx": {
-        "citations": 62,
-        "datestamp": "2024-03-29"
+        "citations": 59,
+        "datestamp": "2025-02-26"
       },
       "Jaguar": {
-        "citations": 326,
-        "datestamp": "2024-03-29"
+        "citations": 333,
+        "datestamp": "2025-02-26"
       },
       "LAMMPS": {
-        "citations": 4620,
-        "datestamp": "2024-03-29"
+        "citations": 4040,
+        "datestamp": "2025-02-26"
       },
       "MOE": {
-        "citations": 1140,
-        "datestamp": "2024-03-29"
+        "citations": 1060,
+        "datestamp": "2025-02-26"
       },
       "MOLCAS": {
-        "citations": 257,
-        "datestamp": "2024-03-29"
+        "citations": 249,
+        "datestamp": "2025-02-26"
       },
       "MOPAC": {
-        "citations": 908,
-        "datestamp": "2024-03-29"
+        "citations": 972,
+        "datestamp": "2025-02-26"
       },
       "MacroModel": {
-        "citations": 503,
-        "datestamp": "2024-03-29"
+        "citations": 485,
+        "datestamp": "2025-02-26"
       },
       "Molpro": {
-        "citations": 791,
-        "datestamp": "2024-03-29"
+        "citations": 721,
+        "datestamp": "2025-02-26"
       },
       "NAMD": {
-        "citations": 1550,
-        "datestamp": "2024-03-29"
+        "citations": 1440,
+        "datestamp": "2025-02-26"
       },
       "NWChem": {
-        "citations": 367,
-        "datestamp": "2024-03-29"
+        "citations": 348,
+        "datestamp": "2025-02-26"
       },
       "ONETEP": {
-        "citations": 58,
-        "datestamp": "2024-03-29"
+        "citations": 52,
+        "datestamp": "2025-02-26"
       },
       "ORCA": {
-        "citations": 1950,
-        "datestamp": "2024-03-29"
+        "citations": 1800,
+        "datestamp": "2025-02-26"
       },
       "Octopus": {
-        "citations": 347,
-        "datestamp": "2024-03-29"
+        "citations": 327,
+        "datestamp": "2025-02-26"
       },
       "OpenMM": {
-        "citations": 578,
-        "datestamp": "2024-03-29"
+        "citations": 520,
+        "datestamp": "2025-02-26"
       },
       "OpenMX": {
-        "citations": 131,
-        "datestamp": "2024-03-29"
+        "citations": 124,
+        "datestamp": "2025-02-26"
       },
       "OpenMolcas": {
-        "citations": 163,
-        "datestamp": "2024-03-29"
+        "citations": 159,
+        "datestamp": "2025-02-26"
       },
       "PWmat": {
-        "citations": 61,
-        "datestamp": "2024-03-29"
+        "citations": 58,
+        "datestamp": "2025-02-26"
       },
       "Psi4": {
-        "citations": 243,
-        "datestamp": "2024-03-29"
+        "citations": 218,
+        "datestamp": "2025-02-26"
       },
       "PySCF": {
-        "citations": 164,
-        "datestamp": "2024-03-29"
+        "citations": 165,
+        "datestamp": "2025-02-26"
       },
       "Q-Chem": {
-        "citations": 610,
-        "datestamp": "2024-03-29"
+        "citations": 577,
+        "datestamp": "2025-02-26"
       },
       "QMCPACK": {
-        "citations": 44,
-        "datestamp": "2024-03-29"
+        "citations": 42,
+        "datestamp": "2025-02-26"
       },
       "Quantum ESPRESSO": {
-        "citations": 2990,
-        "datestamp": "2024-03-29"
+        "citations": 2780,
+        "datestamp": "2025-02-26"
       },
       "RASPA": {
-        "citations": 206,
-        "datestamp": "2024-03-29"
+        "citations": 181,
+        "datestamp": "2025-02-26"
       },
       "SIESTA": {
-        "citations": 831,
-        "datestamp": "2024-03-29"
+        "citations": 751,
+        "datestamp": "2025-02-26"
       },
       "TB-LMTO-ASA": {
-        "citations": 57,
-        "datestamp": "2024-03-29"
+        "citations": 53,
+        "datestamp": "2025-02-26"
       },
       "TINKER": {
-        "citations": 442,
-        "datestamp": "2024-03-29"
+        "citations": 422,
+        "datestamp": "2025-02-26"
       },
       "TURBOMOLE": {
-        "citations": 559,
-        "datestamp": "2024-03-29"
+        "citations": 509,
+        "datestamp": "2025-02-26"
       },
       "TeraChem": {
-        "citations": 97,
-        "datestamp": "2024-03-29"
+        "citations": 95,
+        "datestamp": "2025-02-26"
       },
       "VASP": {
-        "citations": 10700,
-        "datestamp": "2024-03-29"
-      },
-      "WHAT IF": {
-        "citations": 101,
-        "datestamp": "2024-03-29"
+        "citations": 9420,
+        "datestamp": "2025-02-26"
       },
       "WIEN2k": {
-        "citations": 1380,
-        "datestamp": "2024-03-29"
+        "citations": 1270,
+        "datestamp": "2025-02-26"
       },
       "Wannier90": {
-        "citations": 507,
-        "datestamp": "2024-03-29"
+        "citations": 490,
+        "datestamp": "2025-02-26"
       },
       "YASARA": {
-        "citations": 508,
-        "datestamp": "2024-03-29"
+        "citations": 467,
+        "datestamp": "2025-02-26"
       },
       "Yambo": {
-        "citations": 133,
-        "datestamp": "2024-03-29"
+        "citations": 126,
+        "datestamp": "2025-02-26"
       },
       "deMon2k": {
-        "citations": 79,
-        "datestamp": "2024-03-29"
+        "citations": 78,
+        "datestamp": "2025-02-26"
       },
       "exciting": {
-        "citations": 53,
-        "datestamp": "2024-03-29"
+        "citations": 47,
+        "datestamp": "2025-02-26"
       },
       "xTB": {
-        "citations": 478,
-        "datestamp": "2024-03-29"
+        "citations": 447,
+        "datestamp": "2025-02-26"
       }
     },
     "year_high": 2021,

--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -2944,420 +2944,308 @@
   "2017-2017": {
     "citations": {
       "ABINIT": {
-        "citations": 360,
-        "datestamp": "2021-01-07"
+        "citations": 345,
+        "datestamp": "2025-03-04"
       },
       "ACEMD": {
-        "citations": 67,
-        "datestamp": "2024-03-06"
-      },
-      "ACES": {
-        "citations": 36,
-        "datestamp": "2021-05-06"
+        "citations": 59,
+        "datestamp": "2025-03-04"
       },
       "ADF": {
-        "citations": 570,
-        "datestamp": "2021-01-07"
-      },
-      "ASW program package": {
-        "citations": 19,
-        "datestamp": "2021-01-17"
+        "citations": 522,
+        "datestamp": "2025-03-04"
       },
       "ATK/QuantumATK": {
-        "citations": 355,
-        "datestamp": "2021-06-16"
+        "citations": 353,
+        "datestamp": "2025-03-04"
       },
       "Amber": {
-        "citations": 1590,
-        "datestamp": "2021-01-07"
-      },
-      "BAGEL": {
-        "citations": 6,
-        "datestamp": "2021-01-07"
-      },
-      "BOSS": {
-        "citations": 20,
-        "datestamp": "2021-08-26"
+        "citations": 1610,
+        "datestamp": "2025-03-04"
       },
       "BerkeleyGW": {
-        "citations": 90,
-        "datestamp": "2023-01-30"
-      },
-      "BigDFT": {
-        "citations": 39,
-        "datestamp": "2021-01-07"
+        "citations": 87,
+        "datestamp": "2025-03-04"
       },
       "BoltzTrap": {
-        "citations": 288,
-        "datestamp": "2022-03-19"
+        "citations": 289,
+        "datestamp": "2025-03-04"
       },
       "CASINO": {
-        "citations": 46,
-        "datestamp": "2025-01-26"
+        "citations": 45,
+        "datestamp": "2025-03-04"
       },
       "CASTEP": {
-        "citations": 1590,
-        "datestamp": "2021-06-30"
+        "citations": 1530,
+        "datestamp": "2025-03-04"
       },
       "CFOUR": {
-        "citations": 156,
-        "datestamp": "2021-01-07"
+        "citations": 140,
+        "datestamp": "2025-03-04"
       },
       "CHARMM": {
-        "citations": 750,
-        "datestamp": "2021-01-07"
+        "citations": 848,
+        "datestamp": "2025-03-04"
       },
       "COLUMBUS": {
         "citations": 47,
-        "datestamp": "2025-01-26"
-      },
-      "CONQUEST O(N)": {
-        "citations": 30,
-        "datestamp": "2021-01-07"
-      },
-      "COSMOS-software": {
-        "citations": 25,
-        "datestamp": "2021-01-07"
+        "datestamp": "2025-03-04"
       },
       "CP2K": {
-        "citations": 489,
-        "datestamp": "2021-05-06"
+        "citations": 491,
+        "datestamp": "2025-03-04"
       },
       "CPMD": {
-        "citations": 325,
-        "datestamp": "2023-01-28"
+        "citations": 320,
+        "datestamp": "2025-03-04"
       },
       "CRYSTAL": {
-        "citations": 380,
-        "datestamp": "2021-04-10"
+        "citations": 376,
+        "datestamp": "2025-03-04"
       },
       "DFTB+": {
-        "citations": 153,
-        "datestamp": "2021-04-20"
+        "citations": 151,
+        "datestamp": "2025-03-04"
       },
       "DIRAC": {
-        "citations": 117,
-        "datestamp": "2021-01-07"
+        "citations": 110,
+        "datestamp": "2025-03-04"
       },
       "DL_POLY": {
-        "citations": 213,
-        "datestamp": "2021-01-07"
+        "citations": 204,
+        "datestamp": "2025-03-04"
       },
       "DMol3": {
-        "citations": 526,
-        "datestamp": "2021-04-10"
+        "citations": 611,
+        "datestamp": "2025-03-04"
       },
       "Dalton": {
         "citations": 401,
-        "datestamp": "2021-01-07"
+        "datestamp": "2025-03-04"
       },
       "Desmond": {
-        "citations": 441,
-        "datestamp": "2021-01-17"
+        "citations": 434,
+        "datestamp": "2025-03-04"
       },
       "Discovery Studio": {
-        "citations": 1200,
-        "datestamp": "2021-01-07"
+        "citations": 1170,
+        "datestamp": "2025-03-04"
       },
       "EPW": {
-        "citations": 47,
-        "datestamp": "2021-04-15"
-      },
-      "ERKALE": {
-        "citations": 5,
-        "datestamp": "2021-01-07"
+        "citations": 51,
+        "datestamp": "2025-03-04"
       },
       "ESPResSo": {
-        "citations": 81,
-        "datestamp": "2021-06-16"
+        "citations": 86,
+        "datestamp": "2025-03-04"
       },
       "Elk": {
-        "citations": 86,
-        "datestamp": "2021-04-19"
+        "citations": 88,
+        "datestamp": "2025-03-04"
       },
       "FEFF": {
-        "citations": 339,
-        "datestamp": "2021-01-07"
+        "citations": 324,
+        "datestamp": "2025-03-04"
       },
       "FHI-aims": {
-        "citations": 159,
-        "datestamp": "2021-01-07"
+        "citations": 161,
+        "datestamp": "2025-03-04"
       },
       "FLEUR": {
         "citations": 48,
-        "datestamp": "2021-01-07"
+        "datestamp": "2025-03-04"
       },
       "FPLO": {
-        "citations": 92,
-        "datestamp": "2021-01-07"
+        "citations": 89,
+        "datestamp": "2025-03-04"
       },
       "Firefly": {
-        "citations": 217,
-        "datestamp": "2021-01-17"
+        "citations": 226,
+        "datestamp": "2025-03-04"
       },
       "FoldX": {
-        "citations": 148,
-        "datestamp": "2021-01-07"
+        "citations": 166,
+        "datestamp": "2025-03-04"
       },
       "GAMESS": {
-        "citations": 969,
-        "datestamp": "2021-01-07"
+        "citations": 876,
+        "datestamp": "2025-03-04"
       },
       "GPAW": {
-        "citations": 168,
-        "datestamp": "2021-01-07"
-      },
-      "GPIUTMD": {
-        "citations": 0,
-        "datestamp": "2021-01-07"
+        "citations": 399,
+        "datestamp": "2025-03-04"
       },
       "GPUMD": {
         "citations": 6,
-        "datestamp": "2024-08-25"
+        "datestamp": "2025-03-04"
       },
       "GROMOS": {
-        "citations": 609,
-        "datestamp": "2023-02-28"
+        "citations": 564,
+        "datestamp": "2025-03-04"
       },
       "GULP": {
-        "citations": 259,
-        "datestamp": "2021-08-26"
+        "citations": 258,
+        "datestamp": "2025-03-04"
       },
       "Gaussian": {
-        "citations": 12000,
-        "datestamp": "2022-02-03"
+        "citations": 11400,
+        "datestamp": "2025-03-04"
       },
       "Gromacs": {
         "citations": 3180,
-        "datestamp": "2021-06-27"
+        "datestamp": "2025-03-04"
       },
       "HOOMD-blue": {
-        "citations": 81,
-        "datestamp": "2021-01-07"
+        "citations": 80,
+        "datestamp": "2025-03-04"
       },
       "Hyperchem": {
-        "citations": 390,
-        "datestamp": "2021-01-17"
+        "citations": 369,
+        "datestamp": "2025-03-04"
       },
       "JDFTx": {
-        "citations": 30,
-        "datestamp": "2024-03-06"
+        "citations": 29,
+        "datestamp": "2025-03-04"
       },
       "Jaguar": {
-        "citations": 315,
-        "datestamp": "2024-03-06"
+        "citations": 310,
+        "datestamp": "2025-03-04"
       },
       "LAMMPS": {
-        "citations": 2840,
-        "datestamp": "2024-03-29"
-      },
-      "LibAtoms / QUIP / GAP": {
-        "citations": 9,
-        "datestamp": "2021-01-07"
-      },
-      "MADNESS": {
-        "citations": 25,
-        "datestamp": "2021-01-07"
-      },
-      "MCCCS Towhee": {
-        "citations": 39,
-        "datestamp": "2021-01-07"
+        "citations": 2690,
+        "datestamp": "2025-03-04"
       },
       "MOE": {
-        "citations": 912,
-        "datestamp": "2021-01-07"
-      },
-      "MOIL": {
-        "citations": 8,
-        "datestamp": "2021-01-07"
+        "citations": 860,
+        "datestamp": "2025-03-04"
       },
       "MOLCAS": {
-        "citations": 293,
-        "datestamp": "2022-03-20"
+        "citations": 282,
+        "datestamp": "2025-03-04"
       },
       "MOPAC": {
-        "citations": 980,
-        "datestamp": "2022-04-15"
-      },
-      "MPQC": {
-        "citations": 6,
-        "datestamp": "2021-01-07"
+        "citations": 979,
+        "datestamp": "2025-03-04"
       },
       "MacroModel": {
         "citations": 468,
-        "datestamp": "2021-01-07"
+        "datestamp": "2025-03-04"
       },
       "Molpro": {
-        "citations": 855,
-        "datestamp": "2021-01-07"
+        "citations": 761,
+        "datestamp": "2025-03-04"
       },
       "NAMD": {
-        "citations": 1250,
-        "datestamp": "2024-03-29"
-      },
-      "NRLMOL": {
-        "citations": 17,
-        "datestamp": "2021-01-07"
+        "citations": 1180,
+        "datestamp": "2025-03-04"
       },
       "NWChem": {
-        "citations": 405,
-        "datestamp": "2021-08-31"
+        "citations": 398,
+        "datestamp": "2025-03-04"
       },
       "ONETEP": {
-        "citations": 60,
-        "datestamp": "2024-03-09"
+        "citations": 56,
+        "datestamp": "2025-03-04"
       },
       "ORCA": {
-        "citations": 853,
-        "datestamp": "2021-01-07"
+        "citations": 882,
+        "datestamp": "2025-03-04"
       },
       "Octopus": {
-        "citations": 214,
-        "datestamp": "2021-01-07"
+        "citations": 227,
+        "datestamp": "2025-03-04"
       },
       "OpenMM": {
-        "citations": 145,
-        "datestamp": "2021-01-17"
+        "citations": 135,
+        "datestamp": "2025-03-04"
       },
       "OpenMX": {
         "citations": 123,
-        "datestamp": "2021-01-07"
+        "datestamp": "2025-03-04"
       },
       "OpenMolcas": {
         "citations": 2,
-        "datestamp": "2022-03-20"
-      },
-      "PARSEC": {
-        "citations": 34,
-        "datestamp": "2021-01-07"
-      },
-      "PLATO": {
-        "citations": 8,
-        "datestamp": "2021-01-07"
-      },
-      "PWPAW / ATOMPAW": {
-        "citations": 29,
-        "datestamp": "2021-01-07"
+        "datestamp": "2025-03-04"
       },
       "PWmat": {
         "citations": 6,
-        "datestamp": "2024-03-06"
+        "datestamp": "2025-03-04"
       },
       "Psi4": {
-        "citations": 107,
-        "datestamp": "2021-01-07"
+        "citations": 102,
+        "datestamp": "2025-03-04"
       },
       "PySCF": {
-        "citations": 30,
-        "datestamp": "2021-01-17"
-      },
-      "Q": {
-        "citations": 26,
-        "datestamp": "2021-01-07"
+        "citations": 33,
+        "datestamp": "2025-03-04"
       },
       "Q-Chem": {
-        "citations": 492,
-        "datestamp": "2021-01-07"
+        "citations": 501,
+        "datestamp": "2025-03-04"
       },
       "QMCPACK": {
-        "citations": 37,
-        "datestamp": "2024-03-09"
-      },
-      "Qbox": {
-        "citations": 31,
-        "datestamp": "2021-01-07"
+        "citations": 40,
+        "datestamp": "2025-03-04"
       },
       "Quantum ESPRESSO": {
-        "citations": 1820,
-        "datestamp": "2021-01-07"
+        "citations": 1790,
+        "datestamp": "2025-03-04"
       },
       "RASPA": {
-        "citations": 81,
-        "datestamp": "2021-04-24"
-      },
-      "RMCprofile": {
-        "citations": 38,
-        "datestamp": "2021-01-07"
-      },
-      "RedMD": {
-        "citations": 1,
-        "datestamp": "2021-01-07"
-      },
-      "S / PHI / nX": {
-        "citations": 10,
-        "datestamp": "2021-01-17"
+        "citations": 77,
+        "datestamp": "2025-03-04"
       },
       "SIESTA": {
-        "citations": 800,
-        "datestamp": "2021-01-07"
-      },
-      "Smeagol": {
-        "citations": 24,
-        "datestamp": "2021-01-07"
+        "citations": 758,
+        "datestamp": "2025-03-04"
       },
       "TB-LMTO-ASA": {
-        "citations": 96,
-        "datestamp": "2021-06-27"
+        "citations": 92,
+        "datestamp": "2025-03-04"
       },
       "TINKER": {
-        "citations": 461,
-        "datestamp": "2023-01-28"
-      },
-      "TREMOLO-X": {
-        "citations": 2,
-        "datestamp": "2021-01-07"
+        "citations": 451,
+        "datestamp": "2025-03-04"
       },
       "TURBOMOLE": {
-        "citations": 665,
-        "datestamp": "2021-01-07"
+        "citations": 660,
+        "datestamp": "2025-03-04"
       },
       "TeraChem": {
-        "citations": 62,
-        "datestamp": "2022-01-10"
+        "citations": 67,
+        "datestamp": "2025-03-04"
       },
       "VASP": {
-        "citations": 6880,
-        "datestamp": "2024-03-29"
-      },
-      "WEST": {
-        "citations": 39,
-        "datestamp": "2021-01-07"
-      },
-      "WHAT IF": {
-        "citations": 116,
-        "datestamp": "2021-06-30"
+        "citations": 6570,
+        "datestamp": "2025-03-04"
       },
       "WIEN2k": {
-        "citations": 1150,
-        "datestamp": "2021-01-07"
+        "citations": 1160,
+        "datestamp": "2025-03-04"
       },
       "Wannier90": {
-        "citations": 244,
-        "datestamp": "2021-04-12"
+        "citations": 245,
+        "datestamp": "2025-03-04"
       },
       "YASARA": {
-        "citations": 288,
-        "datestamp": "2021-01-07"
+        "citations": 278,
+        "datestamp": "2025-03-04"
       },
       "Yambo": {
-        "citations": 73,
-        "datestamp": "2021-01-07"
+        "citations": 78,
+        "datestamp": "2025-03-04"
       },
       "deMon2k": {
         "citations": 56,
-        "datestamp": "2024-03-06"
+        "datestamp": "2025-03-04"
       },
       "exciting": {
-        "citations": 33,
-        "datestamp": "2024-03-06"
-      },
-      "gSAFT": {
-        "citations": 13,
-        "datestamp": "2021-01-07"
+        "citations": 31,
+        "datestamp": "2025-03-04"
       },
       "xTB": {
-        "citations": 21,
-        "datestamp": "2021-01-17"
+        "citations": 25,
+        "datestamp": "2025-03-04"
       }
     },
     "year_high": 2017,

--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -5152,312 +5152,308 @@
   "2023-2023": {
     "citations": {
       "ABINIT": {
-        "citations": 343,
-        "datestamp": "2024-03-29"
+        "citations": 307,
+        "datestamp": "2025-02-25"
       },
       "ACEMD": {
-        "citations": 75,
-        "datestamp": "2024-03-29"
+        "citations": 66,
+        "datestamp": "2025-02-25"
       },
       "ADF": {
-        "citations": 542,
-        "datestamp": "2024-03-29"
+        "citations": 523,
+        "datestamp": "2025-02-25"
       },
       "ATK/QuantumATK": {
-        "citations": 748,
-        "datestamp": "2024-03-29"
+        "citations": 730,
+        "datestamp": "2025-02-25"
       },
       "Amber": {
-        "citations": 2550,
-        "datestamp": "2024-03-29"
+        "citations": 2230,
+        "datestamp": "2025-02-25"
       },
       "BerkeleyGW": {
-        "citations": 118,
-        "datestamp": "2024-03-29"
+        "citations": 112,
+        "datestamp": "2025-02-25"
       },
       "BoltzTrap": {
-        "citations": 792,
-        "datestamp": "2024-03-29"
+        "citations": 676,
+        "datestamp": "2025-02-25"
       },
       "CASINO": {
         "citations": 61,
         "datestamp": "2025-01-26"
       },
       "CASTEP": {
-        "citations": 2850,
-        "datestamp": "2024-03-29"
+        "citations": 2330,
+        "datestamp": "2025-02-25"
       },
       "CFOUR": {
-        "citations": 173,
-        "datestamp": "2024-03-29"
+        "citations": 157,
+        "datestamp": "2025-02-25"
       },
       "CHARMM": {
-        "citations": 931,
-        "datestamp": "2024-03-29"
+        "citations": 842,
+        "datestamp": "2025-02-25"
       },
       "COLUMBUS": {
-        "citations": 53,
-        "datestamp": "2024-03-29"
+        "citations": 49,
+        "datestamp": "2025-02-25"
       },
       "CP2K": {
-        "citations": 1040,
-        "datestamp": "2024-03-29"
+        "citations": 962,
+        "datestamp": "2025-02-25"
       },
       "CPMD": {
-        "citations": 198,
-        "datestamp": "2024-03-29"
+        "citations": 199,
+        "datestamp": "2025-02-25"
       },
       "CRYSTAL": {
-        "citations": 390,
-        "datestamp": "2024-03-29"
+        "citations": 355,
+        "datestamp": "2025-02-25"
       },
       "DFTB+": {
-        "citations": 81,
-        "datestamp": "2024-03-29"
+        "citations": 82,
+        "datestamp": "2025-02-25"
       },
       "DIRAC": {
-        "citations": 178,
-        "datestamp": "2024-03-29"
+        "citations": 157,
+        "datestamp": "2025-02-25"
       },
       "DL_POLY": {
-        "citations": 157,
-        "datestamp": "2024-03-29"
+        "citations": 147,
+        "datestamp": "2025-02-25"
       },
       "DMol3": {
-        "citations": 947,
-        "datestamp": "2024-03-29"
+        "citations": 767,
+        "datestamp": "2025-02-25"
       },
       "Dalton": {
-        "citations": 482,
-        "datestamp": "2024-03-29"
+        "citations": 412,
+        "datestamp": "2025-02-25"
       },
       "Desmond": {
-        "citations": 2100,
-        "datestamp": "2024-03-29"
+        "citations": 1770,
+        "datestamp": "2025-02-25"
       },
       "Discovery Studio": {
-        "citations": 1060,
-        "datestamp": "2024-03-29"
+        "citations": 956,
+        "datestamp": "2025-02-25"
       },
       "EPW": {
-        "citations": 219,
-        "datestamp": "2024-03-29"
+        "citations": 204,
+        "datestamp": "2025-02-25"
       },
       "ESPResSo": {
-        "citations": 112,
-        "datestamp": "2024-03-29"
+        "citations": 111,
+        "datestamp": "2025-02-25"
       },
       "Elk": {
-        "citations": 83,
-        "datestamp": "2024-03-29"
+        "citations": 69,
+        "datestamp": "2025-02-25"
       },
       "FEFF": {
-        "citations": 232,
-        "datestamp": "2024-03-29"
+        "citations": 223,
+        "datestamp": "2025-02-25"
       },
       "FHI-aims": {
-        "citations": 240,
-        "datestamp": "2024-03-29"
+        "citations": 222,
+        "datestamp": "2025-02-25"
       },
       "FLEUR": {
         "citations": 56,
-        "datestamp": "2024-03-29"
+        "datestamp": "2025-02-25"
       },
       "FPLO": {
-        "citations": 123,
-        "datestamp": "2024-03-29"
+        "citations": 110,
+        "datestamp": "2025-02-25"
       },
       "Firefly": {
-        "citations": 112,
-        "datestamp": "2024-03-29"
+        "citations": 104,
+        "datestamp": "2025-02-25"
       },
       "FoldX": {
-        "citations": 345,
-        "datestamp": "2024-03-29"
+        "citations": 299,
+        "datestamp": "2025-02-25"
       },
       "GAMESS": {
-        "citations": 757,
-        "datestamp": "2024-03-29"
+        "citations": 668,
+        "datestamp": "2025-02-25"
       },
       "GPAW": {
-        "citations": 279,
-        "datestamp": "2024-03-29"
+        "citations": 302,
+        "datestamp": "2025-02-25"
       },
       "GPUMD": {
-        "citations": 66,
-        "datestamp": "2024-08-25"
+        "citations": 62,
+        "datestamp": "2025-02-25"
       },
       "GROMOS": {
-        "citations": 749,
-        "datestamp": "2024-03-29"
+        "citations": 630,
+        "datestamp": "2025-02-25"
       },
       "GULP": {
-        "citations": 243,
-        "datestamp": "2024-03-29"
+        "citations": 231,
+        "datestamp": "2025-02-25"
       },
       "Gaussian": {
-        "citations": 14600,
-        "datestamp": "2024-03-29"
+        "citations": 13000,
+        "datestamp": "2025-02-25"
       },
       "Gromacs": {
-        "citations": 6860,
-        "datestamp": "2024-03-29"
+        "citations": 5950,
+        "datestamp": "2025-02-25"
       },
       "HOOMD-blue": {
-        "citations": 178,
-        "datestamp": "2024-03-29"
+        "citations": 163,
+        "datestamp": "2025-02-25"
       },
       "Hyperchem": {
-        "citations": 244,
-        "datestamp": "2024-03-29"
+        "citations": 229,
+        "datestamp": "2025-02-25"
       },
       "JDFTx": {
-        "citations": 73,
-        "datestamp": "2024-03-29"
+        "citations": 69,
+        "datestamp": "2025-02-25"
       },
       "Jaguar": {
-        "citations": 316,
-        "datestamp": "2024-03-29"
+        "citations": 319,
+        "datestamp": "2025-02-25"
       },
       "LAMMPS": {
-        "citations": 4770,
-        "datestamp": "2024-03-29"
+        "citations": 4210,
+        "datestamp": "2025-02-25"
       },
       "MOE": {
-        "citations": 1160,
-        "datestamp": "2024-03-29"
+        "citations": 1060,
+        "datestamp": "2025-02-25"
       },
       "MOLCAS": {
-        "citations": 190,
-        "datestamp": "2024-03-29"
+        "citations": 169,
+        "datestamp": "2025-02-25"
       },
       "MOPAC": {
-        "citations": 959,
-        "datestamp": "2024-03-29"
+        "citations": 935,
+        "datestamp": "2025-02-25"
       },
       "MacroModel": {
-        "citations": 511,
-        "datestamp": "2024-03-29"
+        "citations": 485,
+        "datestamp": "2025-02-25"
       },
       "Molpro": {
-        "citations": 771,
-        "datestamp": "2024-03-29"
+        "citations": 710,
+        "datestamp": "2025-02-25"
       },
       "NAMD": {
-        "citations": 1440,
-        "datestamp": "2024-03-29"
+        "citations": 1270,
+        "datestamp": "2025-02-25"
       },
       "NWChem": {
-        "citations": 276,
-        "datestamp": "2024-03-29"
+        "citations": 249,
+        "datestamp": "2025-02-25"
       },
       "ONETEP": {
-        "citations": 53,
-        "datestamp": "2024-03-29"
+        "citations": 49,
+        "datestamp": "2025-02-25"
       },
       "ORCA": {
-        "citations": 2930,
-        "datestamp": "2024-03-29"
+        "citations": 2600,
+        "datestamp": "2025-02-25"
       },
       "Octopus": {
-        "citations": 426,
-        "datestamp": "2024-03-29"
+        "citations": 408,
+        "datestamp": "2025-02-25"
       },
       "OpenMM": {
-        "citations": 968,
-        "datestamp": "2024-03-29"
+        "citations": 838,
+        "datestamp": "2025-02-25"
       },
       "OpenMX": {
-        "citations": 171,
-        "datestamp": "2024-03-29"
+        "citations": 146,
+        "datestamp": "2025-02-25"
       },
       "OpenMolcas": {
-        "citations": 190,
-        "datestamp": "2024-03-29"
+        "citations": 179,
+        "datestamp": "2025-02-25"
       },
       "PWmat": {
-        "citations": 92,
-        "datestamp": "2024-03-29"
+        "citations": 88,
+        "datestamp": "2025-02-25"
       },
       "Psi4": {
-        "citations": 235,
-        "datestamp": "2024-03-29"
+        "citations": 220,
+        "datestamp": "2025-02-25"
       },
       "PySCF": {
-        "citations": 305,
-        "datestamp": "2024-03-29"
+        "citations": 249,
+        "datestamp": "2025-02-25"
       },
       "Q-Chem": {
-        "citations": 522,
-        "datestamp": "2024-03-29"
+        "citations": 498,
+        "datestamp": "2025-02-25"
       },
       "QMCPACK": {
-        "citations": 64,
-        "datestamp": "2024-03-29"
+        "citations": 63,
+        "datestamp": "2025-02-25"
       },
       "Quantum ESPRESSO": {
-        "citations": 3630,
-        "datestamp": "2024-03-29"
+        "citations": 3240,
+        "datestamp": "2025-02-25"
       },
       "RASPA": {
-        "citations": 251,
-        "datestamp": "2024-03-29"
+        "citations": 234,
+        "datestamp": "2025-02-25"
       },
       "SIESTA": {
-        "citations": 798,
-        "datestamp": "2024-03-29"
+        "citations": 723,
+        "datestamp": "2025-02-25"
       },
       "TB-LMTO-ASA": {
-        "citations": 60,
-        "datestamp": "2024-03-29"
+        "citations": 57,
+        "datestamp": "2025-02-25"
       },
       "TINKER": {
-        "citations": 430,
-        "datestamp": "2024-03-29"
+        "citations": 423,
+        "datestamp": "2025-02-25"
       },
       "TURBOMOLE": {
-        "citations": 568,
-        "datestamp": "2024-03-29"
+        "citations": 497,
+        "datestamp": "2025-02-25"
       },
       "TeraChem": {
-        "citations": 92,
-        "datestamp": "2024-03-29"
+        "citations": 86,
+        "datestamp": "2025-02-25"
       },
       "VASP": {
-        "citations": 13400,
-        "datestamp": "2024-03-29"
-      },
-      "WHAT IF": {
-        "citations": 77,
-        "datestamp": "2024-03-29"
+        "citations": 11600,
+        "datestamp": "2025-02-25"
       },
       "WIEN2k": {
-        "citations": 1400,
-        "datestamp": "2024-03-29"
+        "citations": 1230,
+        "datestamp": "2025-02-25"
       },
       "Wannier90": {
-        "citations": 783,
-        "datestamp": "2024-03-29"
+        "citations": 662,
+        "datestamp": "2025-02-25"
       },
       "YASARA": {
-        "citations": 470,
-        "datestamp": "2024-03-29"
+        "citations": 451,
+        "datestamp": "2025-02-25"
       },
       "Yambo": {
-        "citations": 140,
-        "datestamp": "2024-03-29"
+        "citations": 127,
+        "datestamp": "2025-02-25"
       },
       "deMon2k": {
-        "citations": 56,
-        "datestamp": "2024-03-29"
+        "citations": 59,
+        "datestamp": "2025-02-25"
       },
       "exciting": {
-        "citations": 53,
-        "datestamp": "2024-03-29"
+        "citations": 45,
+        "datestamp": "2025-02-25"
       },
       "xTB": {
-        "citations": 906,
-        "datestamp": "2024-03-29"
+        "citations": 795,
+        "datestamp": "2025-02-25"
       }
     },
     "year_high": 2023,
@@ -5492,6 +5488,10 @@
       "BoltzTrap": {
         "citations": 929,
         "datestamp": "2025-02-23"
+      },
+      "CASINO": {
+        "citations": 38,
+        "datestamp": "2025-02-26"
       },
       "CASTEP": {
         "citations": 3110,

--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -4382,308 +4382,308 @@
   "2022-2022": {
     "citations": {
       "ABINIT": {
-        "citations": 326,
-        "datestamp": "2025-02-26"
+        "citations": 327,
+        "datestamp": "2025-03-06"
       },
       "ACEMD": {
         "citations": 59,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "ADF": {
         "citations": 565,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "ATK/QuantumATK": {
         "citations": 695,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "Amber": {
         "citations": 2510,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "BerkeleyGW": {
         "citations": 108,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "BoltzTrap": {
         "citations": 688,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "CASINO": {
         "citations": 39,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "CASTEP": {
         "citations": 2560,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "CFOUR": {
-        "citations": 173,
-        "datestamp": "2025-02-26"
+        "citations": 174,
+        "datestamp": "2025-03-06"
       },
       "CHARMM": {
-        "citations": 848,
-        "datestamp": "2025-02-26"
+        "citations": 849,
+        "datestamp": "2025-03-06"
       },
       "COLUMBUS": {
         "citations": 51,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "CP2K": {
         "citations": 835,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "CPMD": {
         "citations": 227,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "CRYSTAL": {
         "citations": 399,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "DFTB+": {
         "citations": 128,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "DIRAC": {
         "citations": 170,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "DL_POLY": {
         "citations": 179,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "DMol3": {
         "citations": 866,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "Dalton": {
         "citations": 497,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "Desmond": {
         "citations": 1510,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "Discovery Studio": {
         "citations": 1160,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "EPW": {
         "citations": 177,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "ESPResSo": {
         "citations": 75,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "Elk": {
         "citations": 107,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "FEFF": {
         "citations": 267,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "FHI-aims": {
         "citations": 230,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "FLEUR": {
         "citations": 46,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "FPLO": {
         "citations": 98,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "Firefly": {
         "citations": 145,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "FoldX": {
         "citations": 283,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "GAMESS": {
         "citations": 737,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "GPAW": {
         "citations": 361,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "GPUMD": {
         "citations": 33,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "GROMOS": {
         "citations": 695,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "GULP": {
         "citations": 208,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "Gaussian": {
-        "citations": 13800,
-        "datestamp": "2025-02-26"
+        "citations": 12700,
+        "datestamp": "2025-03-06"
       },
       "Gromacs": {
-        "citations": 5850,
-        "datestamp": "2025-02-26"
+        "citations": 5860,
+        "datestamp": "2025-03-06"
       },
       "HOOMD-blue": {
         "citations": 135,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "Hyperchem": {
-        "citations": 284,
-        "datestamp": "2025-02-26"
+        "citations": 285,
+        "datestamp": "2025-03-06"
       },
       "JDFTx": {
         "citations": 68,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "Jaguar": {
         "citations": 310,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "LAMMPS": {
         "citations": 4380,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "MOE": {
         "citations": 1160,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "MOLCAS": {
         "citations": 212,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "MOPAC": {
         "citations": 924,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "MacroModel": {
         "citations": 499,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "Molpro": {
-        "citations": 741,
-        "datestamp": "2025-02-26"
+        "citations": 742,
+        "datestamp": "2025-03-07"
       },
       "NAMD": {
         "citations": 1470,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "NWChem": {
         "citations": 291,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "ONETEP": {
         "citations": 47,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "ORCA": {
         "citations": 2270,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "Octopus": {
         "citations": 346,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "OpenMM": {
         "citations": 667,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "OpenMX": {
         "citations": 147,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "OpenMolcas": {
-        "citations": 168,
-        "datestamp": "2025-02-26"
+        "citations": 169,
+        "datestamp": "2025-03-07"
       },
       "PWmat": {
         "citations": 81,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "Psi4": {
         "citations": 244,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "PySCF": {
         "citations": 227,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "Q-Chem": {
         "citations": 488,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "QMCPACK": {
         "citations": 46,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "Quantum ESPRESSO": {
         "citations": 3070,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "RASPA": {
         "citations": 213,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "SIESTA": {
-        "citations": 837,
-        "datestamp": "2025-02-26"
+        "citations": 838,
+        "datestamp": "2025-03-07"
       },
       "TB-LMTO-ASA": {
         "citations": 62,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "TINKER": {
-        "citations": 393,
-        "datestamp": "2025-02-26"
+        "citations": 394,
+        "datestamp": "2025-03-07"
       },
       "TURBOMOLE": {
         "citations": 510,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "TeraChem": {
         "citations": 95,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "VASP": {
         "citations": 11500,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "WIEN2k": {
         "citations": 1340,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "Wannier90": {
         "citations": 593,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "YASARA": {
-        "citations": 488,
-        "datestamp": "2025-02-26"
+        "citations": 489,
+        "datestamp": "2025-03-07"
       },
       "Yambo": {
         "citations": 110,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       },
       "deMon2k": {
         "citations": 69,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "exciting": {
         "citations": 59,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-06"
       },
       "xTB": {
         "citations": 672,
-        "datestamp": "2025-02-26"
+        "datestamp": "2025-03-07"
       }
     },
     "year_high": 2022,

--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -3366,420 +3366,308 @@
   "2018-2018": {
     "citations": {
       "ABINIT": {
-        "citations": 340,
-        "datestamp": "2021-01-04"
+        "citations": 363,
+        "datestamp": "2025-03-02"
       },
       "ACEMD": {
-        "citations": 71,
-        "datestamp": "2024-03-06"
-      },
-      "ACES": {
-        "citations": 28,
-        "datestamp": "2021-05-06"
+        "citations": 63,
+        "datestamp": "2025-03-02"
       },
       "ADF": {
-        "citations": 563,
-        "datestamp": "2021-01-04"
-      },
-      "ASW program package": {
-        "citations": 22,
-        "datestamp": "2021-01-17"
+        "citations": 519,
+        "datestamp": "2025-03-02"
       },
       "ATK/QuantumATK": {
-        "citations": 385,
-        "datestamp": "2021-06-16"
+        "citations": 389,
+        "datestamp": "2025-03-02"
       },
       "Amber": {
-        "citations": 1790,
-        "datestamp": "2021-01-04"
-      },
-      "BAGEL": {
-        "citations": 15,
-        "datestamp": "2021-01-04"
-      },
-      "BOSS": {
-        "citations": 25,
-        "datestamp": "2021-08-26"
+        "citations": 1760,
+        "datestamp": "2025-03-02"
       },
       "BerkeleyGW": {
         "citations": 84,
-        "datestamp": "2023-01-30"
-      },
-      "BigDFT": {
-        "citations": 31,
-        "datestamp": "2021-01-04"
+        "datestamp": "2025-03-02"
       },
       "BoltzTrap": {
-        "citations": 364,
-        "datestamp": "2022-03-19"
+        "citations": 359,
+        "datestamp": "2025-03-02"
       },
       "CASINO": {
-        "citations": 39,
-        "datestamp": "2025-01-26"
+        "citations": 38,
+        "datestamp": "2025-03-02"
       },
       "CASTEP": {
-        "citations": 1600,
-        "datestamp": "2021-06-30"
+        "citations": 1630,
+        "datestamp": "2025-03-02"
       },
       "CFOUR": {
-        "citations": 148,
-        "datestamp": "2021-01-04"
+        "citations": 131,
+        "datestamp": "2025-03-02"
       },
       "CHARMM": {
-        "citations": 802,
-        "datestamp": "2021-01-04"
+        "citations": 853,
+        "datestamp": "2025-03-02"
       },
       "COLUMBUS": {
-        "citations": 46,
-        "datestamp": "2025-01-26"
-      },
-      "CONQUEST O(N)": {
-        "citations": 38,
-        "datestamp": "2021-01-04"
-      },
-      "COSMOS-software": {
-        "citations": 31,
-        "datestamp": "2021-01-04"
+        "citations": 45,
+        "datestamp": "2025-03-02"
       },
       "CP2K": {
-        "citations": 548,
-        "datestamp": "2021-05-06"
+        "citations": 559,
+        "datestamp": "2025-03-02"
       },
       "CPMD": {
-        "citations": 305,
-        "datestamp": "2023-01-28"
+        "citations": 304,
+        "datestamp": "2025-03-02"
       },
       "CRYSTAL": {
-        "citations": 380,
-        "datestamp": "2021-04-10"
+        "citations": 378,
+        "datestamp": "2025-03-02"
       },
       "DFTB+": {
-        "citations": 197,
-        "datestamp": "2021-04-20"
+        "citations": 199,
+        "datestamp": "2025-03-02"
       },
       "DIRAC": {
-        "citations": 126,
-        "datestamp": "2021-01-04"
+        "citations": 123,
+        "datestamp": "2025-03-02"
       },
       "DL_POLY": {
-        "citations": 216,
-        "datestamp": "2021-01-04"
+        "citations": 204,
+        "datestamp": "2025-03-02"
       },
       "DMol3": {
-        "citations": 536,
-        "datestamp": "2021-04-10"
+        "citations": 651,
+        "datestamp": "2025-03-02"
       },
       "Dalton": {
-        "citations": 399,
-        "datestamp": "2021-01-04"
+        "citations": 385,
+        "datestamp": "2025-03-02"
       },
       "Desmond": {
-        "citations": 553,
-        "datestamp": "2021-01-17"
+        "citations": 544,
+        "datestamp": "2025-03-02"
       },
       "Discovery Studio": {
-        "citations": 1240,
-        "datestamp": "2021-01-04"
+        "citations": 1190,
+        "datestamp": "2025-03-02"
       },
       "EPW": {
-        "citations": 81,
-        "datestamp": "2021-04-15"
-      },
-      "ERKALE": {
-        "citations": 7,
-        "datestamp": "2021-01-04"
+        "citations": 80,
+        "datestamp": "2025-03-02"
       },
       "ESPResSo": {
-        "citations": 107,
-        "datestamp": "2021-06-16"
+        "citations": 101,
+        "datestamp": "2025-03-02"
       },
       "Elk": {
-        "citations": 88,
-        "datestamp": "2021-04-19"
+        "citations": 84,
+        "datestamp": "2025-03-02"
       },
       "FEFF": {
-        "citations": 318,
-        "datestamp": "2021-01-04"
+        "citations": 296,
+        "datestamp": "2025-03-02"
       },
       "FHI-aims": {
-        "citations": 166,
-        "datestamp": "2021-01-04"
+        "citations": 165,
+        "datestamp": "2025-03-02"
       },
       "FLEUR": {
-        "citations": 45,
-        "datestamp": "2021-01-04"
+        "citations": 46,
+        "datestamp": "2025-03-02"
       },
       "FPLO": {
-        "citations": 95,
-        "datestamp": "2021-01-04"
+        "citations": 92,
+        "datestamp": "2025-03-02"
       },
       "Firefly": {
-        "citations": 171,
-        "datestamp": "2021-01-17"
+        "citations": 185,
+        "datestamp": "2025-03-02"
       },
       "FoldX": {
-        "citations": 175,
-        "datestamp": "2021-01-04"
+        "citations": 191,
+        "datestamp": "2025-03-02"
       },
       "GAMESS": {
-        "citations": 907,
-        "datestamp": "2021-01-04"
+        "citations": 816,
+        "datestamp": "2025-03-02"
       },
       "GPAW": {
-        "citations": 163,
-        "datestamp": "2021-01-04"
-      },
-      "GPIUTMD": {
-        "citations": 0,
-        "datestamp": "2021-01-04"
+        "citations": 334,
+        "datestamp": "2025-03-02"
       },
       "GPUMD": {
-        "citations": 10,
-        "datestamp": "2024-08-25"
+        "citations": 9,
+        "datestamp": "2025-03-02"
       },
       "GROMOS": {
-        "citations": 697,
-        "datestamp": "2023-02-28"
+        "citations": 631,
+        "datestamp": "2025-03-02"
       },
       "GULP": {
-        "citations": 262,
-        "datestamp": "2021-08-26"
+        "citations": 276,
+        "datestamp": "2025-03-02"
       },
       "Gaussian": {
-        "citations": 12200,
-        "datestamp": "2022-02-03"
+        "citations": 11600,
+        "datestamp": "2025-03-02"
       },
       "Gromacs": {
-        "citations": 3660,
-        "datestamp": "2021-06-27"
+        "citations": 3630,
+        "datestamp": "2025-03-02"
       },
       "HOOMD-blue": {
-        "citations": 112,
-        "datestamp": "2021-01-04"
+        "citations": 113,
+        "datestamp": "2025-03-02"
       },
       "Hyperchem": {
-        "citations": 329,
-        "datestamp": "2021-01-17"
+        "citations": 316,
+        "datestamp": "2025-03-02"
       },
       "JDFTx": {
-        "citations": 25,
-        "datestamp": "2024-03-06"
+        "citations": 26,
+        "datestamp": "2025-03-02"
       },
       "Jaguar": {
-        "citations": 296,
-        "datestamp": "2024-03-06"
+        "citations": 305,
+        "datestamp": "2025-03-02"
       },
       "LAMMPS": {
-        "citations": 3470,
-        "datestamp": "2024-03-29"
-      },
-      "LibAtoms / QUIP / GAP": {
-        "citations": 22,
-        "datestamp": "2021-01-04"
-      },
-      "MADNESS": {
-        "citations": 17,
-        "datestamp": "2021-01-07"
-      },
-      "MCCCS Towhee": {
-        "citations": 36,
-        "datestamp": "2021-01-04"
+        "citations": 3220,
+        "datestamp": "2025-03-02"
       },
       "MOE": {
-        "citations": 951,
-        "datestamp": "2021-01-04"
-      },
-      "MOIL": {
-        "citations": 6,
-        "datestamp": "2021-01-04"
+        "citations": 855,
+        "datestamp": "2025-03-02"
       },
       "MOLCAS": {
-        "citations": 323,
-        "datestamp": "2022-03-20"
+        "citations": 315,
+        "datestamp": "2025-03-02"
       },
       "MOPAC": {
-        "citations": 988,
-        "datestamp": "2022-04-15"
-      },
-      "MPQC": {
-        "citations": 7,
-        "datestamp": "2021-01-04"
+        "citations": 994,
+        "datestamp": "2025-03-02"
       },
       "MacroModel": {
-        "citations": 494,
-        "datestamp": "2021-01-04"
+        "citations": 506,
+        "datestamp": "2025-03-02"
       },
       "Molpro": {
-        "citations": 885,
-        "datestamp": "2021-01-04"
+        "citations": 798,
+        "datestamp": "2025-03-02"
       },
       "NAMD": {
-        "citations": 1320,
-        "datestamp": "2024-03-29"
-      },
-      "NRLMOL": {
-        "citations": 8,
-        "datestamp": "2021-01-04"
+        "citations": 1240,
+        "datestamp": "2025-03-02"
       },
       "NWChem": {
-        "citations": 377,
-        "datestamp": "2021-08-31"
+        "citations": 365,
+        "datestamp": "2025-03-02"
       },
       "ONETEP": {
-        "citations": 49,
-        "datestamp": "2024-03-09"
+        "citations": 47,
+        "datestamp": "2025-03-02"
       },
       "ORCA": {
         "citations": 1030,
-        "datestamp": "2021-01-04"
+        "datestamp": "2025-03-02"
       },
       "Octopus": {
-        "citations": 236,
-        "datestamp": "2021-01-04"
+        "citations": 220,
+        "datestamp": "2025-03-02"
       },
       "OpenMM": {
-        "citations": 244,
-        "datestamp": "2021-01-17"
+        "citations": 226,
+        "datestamp": "2025-03-02"
       },
       "OpenMX": {
-        "citations": 117,
-        "datestamp": "2021-01-04"
+        "citations": 112,
+        "datestamp": "2025-03-02"
       },
       "OpenMolcas": {
-        "citations": 15,
-        "datestamp": "2022-03-20"
-      },
-      "PARSEC": {
-        "citations": 42,
-        "datestamp": "2021-01-04"
-      },
-      "PLATO": {
-        "citations": 4,
-        "datestamp": "2021-01-04"
-      },
-      "PWPAW / ATOMPAW": {
-        "citations": 26,
-        "datestamp": "2021-01-04"
+        "citations": 16,
+        "datestamp": "2025-03-02"
       },
       "PWmat": {
         "citations": 13,
-        "datestamp": "2024-03-06"
+        "datestamp": "2025-03-02"
       },
       "Psi4": {
-        "citations": 138,
-        "datestamp": "2021-01-04"
+        "citations": 125,
+        "datestamp": "2025-03-02"
       },
       "PySCF": {
-        "citations": 62,
-        "datestamp": "2021-01-17"
-      },
-      "Q": {
-        "citations": 21,
-        "datestamp": "2021-01-07"
+        "citations": 59,
+        "datestamp": "2025-03-02"
       },
       "Q-Chem": {
-        "citations": 534,
-        "datestamp": "2021-01-04"
+        "citations": 495,
+        "datestamp": "2025-03-02"
       },
       "QMCPACK": {
         "citations": 40,
-        "datestamp": "2024-03-09"
-      },
-      "Qbox": {
-        "citations": 36,
-        "datestamp": "2021-01-04"
+        "datestamp": "2025-03-02"
       },
       "Quantum ESPRESSO": {
-        "citations": 2030,
-        "datestamp": "2021-01-04"
+        "citations": 1970,
+        "datestamp": "2025-03-02"
       },
       "RASPA": {
-        "citations": 120,
-        "datestamp": "2021-04-24"
-      },
-      "RMCprofile": {
-        "citations": 28,
-        "datestamp": "2021-01-04"
-      },
-      "RedMD": {
-        "citations": 1,
-        "datestamp": "2021-01-04"
-      },
-      "S / PHI / nX": {
-        "citations": 9,
-        "datestamp": "2021-01-17"
+        "citations": 126,
+        "datestamp": "2025-03-02"
       },
       "SIESTA": {
-        "citations": 924,
-        "datestamp": "2021-01-04"
-      },
-      "Smeagol": {
-        "citations": 16,
-        "datestamp": "2021-01-04"
+        "citations": 896,
+        "datestamp": "2025-03-02"
       },
       "TB-LMTO-ASA": {
-        "citations": 88,
-        "datestamp": "2021-06-27"
+        "citations": 92,
+        "datestamp": "2025-03-02"
       },
       "TINKER": {
-        "citations": 413,
-        "datestamp": "2023-01-28"
-      },
-      "TREMOLO-X": {
-        "citations": 1,
-        "datestamp": "2021-01-04"
+        "citations": 420,
+        "datestamp": "2025-03-02"
       },
       "TURBOMOLE": {
-        "citations": 630,
-        "datestamp": "2021-01-04"
+        "citations": 608,
+        "datestamp": "2025-03-02"
       },
       "TeraChem": {
         "citations": 52,
-        "datestamp": "2022-01-10"
+        "datestamp": "2025-03-02"
       },
       "VASP": {
-        "citations": 7630,
-        "datestamp": "2024-03-29"
-      },
-      "WEST": {
-        "citations": 36,
-        "datestamp": "2021-01-07"
-      },
-      "WHAT IF": {
-        "citations": 108,
-        "datestamp": "2021-06-30"
+        "citations": 7230,
+        "datestamp": "2025-03-02"
       },
       "WIEN2k": {
-        "citations": 1210,
-        "datestamp": "2021-01-04"
+        "citations": 1170,
+        "datestamp": "2025-03-02"
       },
       "Wannier90": {
-        "citations": 301,
-        "datestamp": "2021-04-12"
+        "citations": 307,
+        "datestamp": "2025-03-02"
       },
       "YASARA": {
-        "citations": 350,
-        "datestamp": "2021-01-04"
+        "citations": 327,
+        "datestamp": "2025-03-02"
       },
       "Yambo": {
-        "citations": 89,
-        "datestamp": "2021-01-04"
+        "citations": 83,
+        "datestamp": "2025-03-02"
       },
       "deMon2k": {
-        "citations": 47,
-        "datestamp": "2024-03-06"
+        "citations": 49,
+        "datestamp": "2025-03-02"
       },
       "exciting": {
-        "citations": 33,
-        "datestamp": "2024-03-06"
-      },
-      "gSAFT": {
-        "citations": 12,
-        "datestamp": "2021-01-04"
+        "citations": 32,
+        "datestamp": "2025-03-02"
       },
       "xTB": {
-        "citations": 52,
-        "datestamp": "2021-01-17"
+        "citations": 57,
+        "datestamp": "2025-03-02"
       }
     },
     "year_high": 2018,
@@ -4714,320 +4602,6 @@
     },
     "year_high": 2021,
     "year_low": 2021
-  },
-  "2022-2022": {
-    "citations": {
-      "ABINIT": {
-        "citations": 334,
-        "datestamp": "2024-03-29"
-      },
-      "ACEMD": {
-        "citations": 68,
-        "datestamp": "2024-03-29"
-      },
-      "ADF": {
-        "citations": 575,
-        "datestamp": "2024-03-29"
-      },
-      "ATK/QuantumATK": {
-        "citations": 706,
-        "datestamp": "2024-03-29"
-      },
-      "Amber": {
-        "citations": 2590,
-        "datestamp": "2024-03-29"
-      },
-      "BerkeleyGW": {
-        "citations": 107,
-        "datestamp": "2024-03-29"
-      },
-      "BoltzTrap": {
-        "citations": 744,
-        "datestamp": "2024-03-29"
-      },
-      "CASINO": {
-        "citations": 41,
-        "datestamp": "2025-01-26"
-      },
-      "CASTEP": {
-        "citations": 2670,
-        "datestamp": "2024-03-29"
-      },
-      "CFOUR": {
-        "citations": 179,
-        "datestamp": "2024-03-29"
-      },
-      "CHARMM": {
-        "citations": 866,
-        "datestamp": "2024-03-29"
-      },
-      "COLUMBUS": {
-        "citations": 53,
-        "datestamp": "2024-03-29"
-      },
-      "CP2K": {
-        "citations": 874,
-        "datestamp": "2024-03-29"
-      },
-      "CPMD": {
-        "citations": 218,
-        "datestamp": "2024-03-29"
-      },
-      "CRYSTAL": {
-        "citations": 397,
-        "datestamp": "2024-03-29"
-      },
-      "DFTB+": {
-        "citations": 127,
-        "datestamp": "2024-03-29"
-      },
-      "DIRAC": {
-        "citations": 170,
-        "datestamp": "2024-03-29"
-      },
-      "DL_POLY": {
-        "citations": 187,
-        "datestamp": "2024-03-29"
-      },
-      "DMol3": {
-        "citations": 935,
-        "datestamp": "2024-03-29"
-      },
-      "Dalton": {
-        "citations": 508,
-        "datestamp": "2024-03-29"
-      },
-      "Desmond": {
-        "citations": 1500,
-        "datestamp": "2024-03-29"
-      },
-      "Discovery Studio": {
-        "citations": 1190,
-        "datestamp": "2024-03-29"
-      },
-      "EPW": {
-        "citations": 184,
-        "datestamp": "2024-03-29"
-      },
-      "ESPResSo": {
-        "citations": 85,
-        "datestamp": "2024-03-29"
-      },
-      "Elk": {
-        "citations": 109,
-        "datestamp": "2024-03-29"
-      },
-      "FEFF": {
-        "citations": 265,
-        "datestamp": "2024-03-29"
-      },
-      "FHI-aims": {
-        "citations": 233,
-        "datestamp": "2024-03-29"
-      },
-      "FLEUR": {
-        "citations": 50,
-        "datestamp": "2024-03-29"
-      },
-      "FPLO": {
-        "citations": 98,
-        "datestamp": "2024-03-29"
-      },
-      "Firefly": {
-        "citations": 145,
-        "datestamp": "2024-03-29"
-      },
-      "FoldX": {
-        "citations": 284,
-        "datestamp": "2024-03-29"
-      },
-      "GAMESS": {
-        "citations": 767,
-        "datestamp": "2024-03-29"
-      },
-      "GPAW": {
-        "citations": 250,
-        "datestamp": "2024-03-29"
-      },
-      "GPUMD": {
-        "citations": 34,
-        "datestamp": "2024-08-25"
-      },
-      "GROMOS": {
-        "citations": 710,
-        "datestamp": "2024-03-29"
-      },
-      "GULP": {
-        "citations": 213,
-        "datestamp": "2024-03-29"
-      },
-      "Gaussian": {
-        "citations": 14200,
-        "datestamp": "2024-03-29"
-      },
-      "Gromacs": {
-        "citations": 6030,
-        "datestamp": "2024-03-29"
-      },
-      "HOOMD-blue": {
-        "citations": 135,
-        "datestamp": "2024-03-29"
-      },
-      "Hyperchem": {
-        "citations": 287,
-        "datestamp": "2024-03-29"
-      },
-      "JDFTx": {
-        "citations": 71,
-        "datestamp": "2024-03-29"
-      },
-      "Jaguar": {
-        "citations": 303,
-        "datestamp": "2024-03-29"
-      },
-      "LAMMPS": {
-        "citations": 4620,
-        "datestamp": "2024-03-29"
-      },
-      "MOE": {
-        "citations": 1170,
-        "datestamp": "2024-03-29"
-      },
-      "MOLCAS": {
-        "citations": 215,
-        "datestamp": "2024-03-29"
-      },
-      "MOPAC": {
-        "citations": 911,
-        "datestamp": "2024-03-29"
-      },
-      "MacroModel": {
-        "citations": 477,
-        "datestamp": "2024-03-29"
-      },
-      "Molpro": {
-        "citations": 773,
-        "datestamp": "2024-03-29"
-      },
-      "NAMD": {
-        "citations": 1500,
-        "datestamp": "2024-03-29"
-      },
-      "NWChem": {
-        "citations": 295,
-        "datestamp": "2024-03-29"
-      },
-      "ONETEP": {
-        "citations": 51,
-        "datestamp": "2024-03-29"
-      },
-      "ORCA": {
-        "citations": 2280,
-        "datestamp": "2024-03-29"
-      },
-      "Octopus": {
-        "citations": 359,
-        "datestamp": "2024-03-29"
-      },
-      "OpenMM": {
-        "citations": 693,
-        "datestamp": "2024-03-29"
-      },
-      "OpenMX": {
-        "citations": 145,
-        "datestamp": "2024-03-29"
-      },
-      "OpenMolcas": {
-        "citations": 163,
-        "datestamp": "2024-03-29"
-      },
-      "PWmat": {
-        "citations": 80,
-        "datestamp": "2024-03-29"
-      },
-      "Psi4": {
-        "citations": 259,
-        "datestamp": "2024-03-29"
-      },
-      "PySCF": {
-        "citations": 231,
-        "datestamp": "2024-03-29"
-      },
-      "Q-Chem": {
-        "citations": 517,
-        "datestamp": "2024-03-29"
-      },
-      "QMCPACK": {
-        "citations": 50,
-        "datestamp": "2024-03-29"
-      },
-      "Quantum ESPRESSO": {
-        "citations": 3200,
-        "datestamp": "2024-03-29"
-      },
-      "RASPA": {
-        "citations": 225,
-        "datestamp": "2024-03-29"
-      },
-      "SIESTA": {
-        "citations": 841,
-        "datestamp": "2024-03-29"
-      },
-      "TB-LMTO-ASA": {
-        "citations": 62,
-        "datestamp": "2024-03-29"
-      },
-      "TINKER": {
-        "citations": 388,
-        "datestamp": "2024-03-29"
-      },
-      "TURBOMOLE": {
-        "citations": 513,
-        "datestamp": "2024-03-29"
-      },
-      "TeraChem": {
-        "citations": 98,
-        "datestamp": "2024-03-29"
-      },
-      "VASP": {
-        "citations": 12100,
-        "datestamp": "2024-03-29"
-      },
-      "WHAT IF": {
-        "citations": 83,
-        "datestamp": "2024-03-29"
-      },
-      "WIEN2k": {
-        "citations": 1400,
-        "datestamp": "2024-03-29"
-      },
-      "Wannier90": {
-        "citations": 620,
-        "datestamp": "2024-03-29"
-      },
-      "YASARA": {
-        "citations": 514,
-        "datestamp": "2024-03-29"
-      },
-      "Yambo": {
-        "citations": 114,
-        "datestamp": "2024-03-29"
-      },
-      "deMon2k": {
-        "citations": 71,
-        "datestamp": "2024-03-29"
-      },
-      "exciting": {
-        "citations": 56,
-        "datestamp": "2024-03-29"
-      },
-      "xTB": {
-        "citations": 681,
-        "datestamp": "2024-03-29"
-      }
-    },
-    "year_high": 2022,
-    "year_low": 2022
   },
   "2022-2022": {
     "citations": {

--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -3788,416 +3788,308 @@
   "2019-2019": {
     "citations": {
       "ABINIT": {
-        "citations": 397,
-        "datestamp": "2021-01-04"
+        "citations": 386,
+        "datestamp": "2025-03-02"
       },
       "ACEMD": {
-        "citations": 78,
-        "datestamp": "2024-03-06"
-      },
-      "ACES": {
-        "citations": 23,
-        "datestamp": "2021-05-06"
+        "citations": 74,
+        "datestamp": "2025-03-02"
       },
       "ADF": {
-        "citations": 596,
-        "datestamp": "2021-01-04"
-      },
-      "ASW program package": {
-        "citations": 18,
-        "datestamp": "2021-01-17"
+        "citations": 555,
+        "datestamp": "2025-03-02"
       },
       "ATK/QuantumATK": {
-        "citations": 390,
-        "datestamp": "2021-06-16"
+        "citations": 406,
+        "datestamp": "2025-03-02"
       },
       "Amber": {
-        "citations": 1950,
-        "datestamp": "2021-01-04"
-      },
-      "BAGEL": {
-        "citations": 25,
-        "datestamp": "2021-01-04"
-      },
-      "BOSS": {
-        "citations": 23,
-        "datestamp": "2021-08-26"
+        "citations": 1860,
+        "datestamp": "2025-03-02"
       },
       "BerkeleyGW": {
-        "citations": 87,
-        "datestamp": "2023-01-30"
-      },
-      "BigDFT": {
-        "citations": 40,
-        "datestamp": "2021-01-04"
+        "citations": 85,
+        "datestamp": "2025-03-02"
       },
       "BoltzTrap": {
-        "citations": 440,
-        "datestamp": "2022-03-19"
+        "citations": 414,
+        "datestamp": "2025-03-02"
       },
       "CASINO": {
-        "citations": 40,
-        "datestamp": "2025-01-26"
+        "citations": 39,
+        "datestamp": "2025-03-02"
       },
       "CASTEP": {
-        "citations": 1690,
-        "datestamp": "2021-06-30"
+        "citations": 1780,
+        "datestamp": "2025-03-02"
       },
       "CFOUR": {
-        "citations": 173,
-        "datestamp": "2021-01-04"
+        "citations": 155,
+        "datestamp": "2025-03-02"
       },
       "CHARMM": {
-        "citations": 721,
-        "datestamp": "2021-01-04"
+        "citations": 789,
+        "datestamp": "2025-03-02"
       },
       "COLUMBUS": {
-        "citations": 45,
-        "datestamp": "2025-01-26"
-      },
-      "COSMOS-software": {
-        "citations": 28,
-        "datestamp": "2021-01-04"
+        "citations": 44,
+        "datestamp": "2025-03-02"
       },
       "CP2K": {
-        "citations": 587,
-        "datestamp": "2021-05-06"
+        "citations": 576,
+        "datestamp": "2025-03-02"
       },
       "CPMD": {
-        "citations": 265,
-        "datestamp": "2023-01-28"
+        "citations": 262,
+        "datestamp": "2025-03-02"
       },
       "CRYSTAL": {
-        "citations": 399,
-        "datestamp": "2021-04-10"
+        "citations": 396,
+        "datestamp": "2025-03-02"
       },
       "DFTB+": {
-        "citations": 212,
-        "datestamp": "2021-04-20"
+        "citations": 220,
+        "datestamp": "2025-03-02"
       },
       "DIRAC": {
-        "citations": 151,
-        "datestamp": "2021-01-04"
+        "citations": 143,
+        "datestamp": "2025-03-02"
       },
       "DL_POLY": {
-        "citations": 190,
-        "datestamp": "2021-01-04"
+        "citations": 165,
+        "datestamp": "2025-03-02"
       },
       "DMol3": {
-        "citations": 530,
-        "datestamp": "2021-04-10"
+        "citations": 674,
+        "datestamp": "2025-03-02"
       },
       "Dalton": {
-        "citations": 418,
-        "datestamp": "2021-01-04"
+        "citations": 396,
+        "datestamp": "2025-03-02"
       },
       "Desmond": {
-        "citations": 602,
-        "datestamp": "2021-01-17"
+        "citations": 561,
+        "datestamp": "2025-03-02"
       },
       "Discovery Studio": {
-        "citations": 1130,
-        "datestamp": "2021-01-04"
+        "citations": 1060,
+        "datestamp": "2025-03-02"
       },
       "EPW": {
-        "citations": 96,
-        "datestamp": "2021-04-15"
-      },
-      "ERKALE": {
-        "citations": 11,
-        "datestamp": "2021-01-04"
+        "citations": 103,
+        "datestamp": "2025-03-02"
       },
       "ESPResSo": {
         "citations": 96,
-        "datestamp": "2021-06-16"
+        "datestamp": "2025-03-02"
       },
       "Elk": {
-        "citations": 86,
-        "datestamp": "2021-04-19"
+        "citations": 90,
+        "datestamp": "2025-03-02"
       },
       "FEFF": {
-        "citations": 231,
-        "datestamp": "2021-01-04"
+        "citations": 253,
+        "datestamp": "2025-03-02"
       },
       "FHI-aims": {
-        "citations": 204,
-        "datestamp": "2021-01-04"
+        "citations": 215,
+        "datestamp": "2025-03-02"
       },
       "FLEUR": {
-        "citations": 43,
-        "datestamp": "2021-01-04"
+        "citations": 36,
+        "datestamp": "2025-03-02"
       },
       "FPLO": {
         "citations": 114,
-        "datestamp": "2021-01-04"
+        "datestamp": "2025-03-02"
       },
       "Firefly": {
-        "citations": 180,
-        "datestamp": "2021-01-17"
+        "citations": 187,
+        "datestamp": "2025-03-02"
       },
       "FoldX": {
-        "citations": 216,
-        "datestamp": "2021-01-04"
+        "citations": 227,
+        "datestamp": "2025-03-02"
       },
       "GAMESS": {
-        "citations": 807,
-        "datestamp": "2021-01-04"
+        "citations": 762,
+        "datestamp": "2025-03-02"
       },
       "GPAW": {
-        "citations": 172,
-        "datestamp": "2021-01-04"
-      },
-      "GPIUTMD": {
-        "citations": 1,
-        "datestamp": "2021-01-04"
+        "citations": 362,
+        "datestamp": "2025-03-02"
       },
       "GPUMD": {
         "citations": 9,
-        "datestamp": "2024-08-25"
+        "datestamp": "2025-03-02"
       },
       "GROMOS": {
-        "citations": 664,
-        "datestamp": "2023-02-28"
+        "citations": 605,
+        "datestamp": "2025-03-02"
       },
       "GULP": {
-        "citations": 233,
-        "datestamp": "2021-08-26"
+        "citations": 238,
+        "datestamp": "2025-03-02"
       },
       "Gaussian": {
-        "citations": 12500,
-        "datestamp": "2022-02-03"
+        "citations": 12000,
+        "datestamp": "2025-03-02"
       },
       "Gromacs": {
-        "citations": 3770,
-        "datestamp": "2021-06-27"
+        "citations": 3730,
+        "datestamp": "2025-03-02"
       },
       "HOOMD-blue": {
-        "citations": 134,
-        "datestamp": "2021-01-04"
+        "citations": 124,
+        "datestamp": "2025-03-02"
       },
       "Hyperchem": {
-        "citations": 314,
-        "datestamp": "2021-01-17"
+        "citations": 324,
+        "datestamp": "2025-03-02"
       },
       "JDFTx": {
-        "citations": 24,
-        "datestamp": "2024-03-06"
+        "citations": 21,
+        "datestamp": "2025-03-02"
       },
       "Jaguar": {
-        "citations": 299,
-        "datestamp": "2024-03-06"
+        "citations": 300,
+        "datestamp": "2025-03-02"
       },
       "LAMMPS": {
-        "citations": 3770,
-        "datestamp": "2024-03-29"
-      },
-      "LibAtoms / QUIP / GAP": {
-        "citations": 23,
-        "datestamp": "2021-01-04"
-      },
-      "MADNESS": {
-        "citations": 17,
-        "datestamp": "2021-01-07"
-      },
-      "MCCCS Towhee": {
-        "citations": 26,
-        "datestamp": "2021-01-04"
+        "citations": 3460,
+        "datestamp": "2025-03-02"
       },
       "MOE": {
-        "citations": 959,
-        "datestamp": "2021-01-04"
-      },
-      "MOIL": {
-        "citations": 5,
-        "datestamp": "2021-01-04"
+        "citations": 873,
+        "datestamp": "2025-03-02"
       },
       "MOLCAS": {
-        "citations": 300,
-        "datestamp": "2022-03-20"
+        "citations": 286,
+        "datestamp": "2025-03-02"
       },
       "MOPAC": {
         "citations": 937,
-        "datestamp": "2022-04-15"
-      },
-      "MPQC": {
-        "citations": 3,
-        "datestamp": "2021-01-04"
+        "datestamp": "2025-03-02"
       },
       "MacroModel": {
-        "citations": 441,
-        "datestamp": "2021-01-04"
+        "citations": 447,
+        "datestamp": "2025-03-02"
       },
       "Molpro": {
-        "citations": 840,
-        "datestamp": "2021-01-04"
+        "citations": 771,
+        "datestamp": "2025-03-02"
       },
       "NAMD": {
-        "citations": 1300,
-        "datestamp": "2024-03-29"
-      },
-      "NRLMOL": {
-        "citations": 22,
-        "datestamp": "2021-01-04"
+        "citations": 1210,
+        "datestamp": "2025-03-02"
       },
       "NWChem": {
-        "citations": 371,
-        "datestamp": "2021-08-31"
+        "citations": 354,
+        "datestamp": "2025-03-02"
       },
       "ONETEP": {
         "citations": 47,
-        "datestamp": "2024-03-09"
+        "datestamp": "2025-03-02"
       },
       "ORCA": {
-        "citations": 1220,
-        "datestamp": "2021-01-04"
+        "citations": 1230,
+        "datestamp": "2025-03-02"
       },
       "Octopus": {
-        "citations": 248,
-        "datestamp": "2021-01-04"
+        "citations": 251,
+        "datestamp": "2025-03-02"
       },
       "OpenMM": {
-        "citations": 245,
-        "datestamp": "2021-01-17"
+        "citations": 263,
+        "datestamp": "2025-03-02"
       },
       "OpenMX": {
-        "citations": 122,
-        "datestamp": "2021-01-04"
+        "citations": 116,
+        "datestamp": "2025-03-02"
       },
       "OpenMolcas": {
-        "citations": 55,
-        "datestamp": "2022-03-20"
-      },
-      "PARSEC": {
-        "citations": 34,
-        "datestamp": "2021-01-04"
-      },
-      "PLATO": {
-        "citations": 5,
-        "datestamp": "2021-01-04"
-      },
-      "PWPAW / ATOMPAW": {
-        "citations": 32,
-        "datestamp": "2021-01-04"
+        "citations": 54,
+        "datestamp": "2025-03-02"
       },
       "PWmat": {
-        "citations": 35,
-        "datestamp": "2024-03-06"
+        "citations": 36,
+        "datestamp": "2025-03-02"
       },
       "Psi4": {
-        "citations": 167,
-        "datestamp": "2021-01-04"
+        "citations": 159,
+        "datestamp": "2025-03-02"
       },
       "PySCF": {
-        "citations": 94,
-        "datestamp": "2021-01-17"
-      },
-      "Q": {
-        "citations": 15,
-        "datestamp": "2021-01-07"
+        "citations": 79,
+        "datestamp": "2025-03-02"
       },
       "Q-Chem": {
-        "citations": 523,
-        "datestamp": "2021-01-04"
+        "citations": 507,
+        "datestamp": "2025-03-02"
       },
       "QMCPACK": {
-        "citations": 54,
-        "datestamp": "2024-03-09"
-      },
-      "Qbox": {
-        "citations": 32,
-        "datestamp": "2021-01-04"
+        "citations": 52,
+        "datestamp": "2025-03-02"
       },
       "Quantum ESPRESSO": {
-        "citations": 2340,
-        "datestamp": "2021-01-04"
+        "citations": 2170,
+        "datestamp": "2025-03-02"
       },
       "RASPA": {
-        "citations": 147,
-        "datestamp": "2021-04-24"
-      },
-      "RMCprofile": {
-        "citations": 51,
-        "datestamp": "2021-01-04"
-      },
-      "RedMD": {
-        "citations": 3,
-        "datestamp": "2021-01-04"
-      },
-      "S / PHI / nX": {
-        "citations": 5,
-        "datestamp": "2021-01-17"
+        "citations": 151,
+        "datestamp": "2025-03-02"
       },
       "SIESTA": {
-        "citations": 908,
-        "datestamp": "2021-01-04"
-      },
-      "Smeagol": {
-        "citations": 17,
-        "datestamp": "2021-01-04"
+        "citations": 880,
+        "datestamp": "2025-03-02"
       },
       "TB-LMTO-ASA": {
-        "citations": 81,
-        "datestamp": "2021-06-27"
+        "citations": 101,
+        "datestamp": "2025-03-02"
       },
       "TINKER": {
-        "citations": 438,
-        "datestamp": "2023-01-28"
-      },
-      "TREMOLO-X": {
-        "citations": 0,
-        "datestamp": "2021-01-04"
+        "citations": 427,
+        "datestamp": "2025-03-02"
       },
       "TURBOMOLE": {
-        "citations": 591,
-        "datestamp": "2021-01-04"
+        "citations": 559,
+        "datestamp": "2025-03-02"
       },
       "TeraChem": {
-        "citations": 81,
-        "datestamp": "2022-01-10"
+        "citations": 78,
+        "datestamp": "2025-03-02"
       },
       "VASP": {
-        "citations": 8480,
-        "datestamp": "2024-03-29"
-      },
-      "WEST": {
-        "citations": 34,
-        "datestamp": "2021-01-07"
-      },
-      "WHAT IF": {
-        "citations": 97,
-        "datestamp": "2021-06-30"
+        "citations": 7960,
+        "datestamp": "2025-03-02"
       },
       "WIEN2k": {
-        "citations": 1300,
-        "datestamp": "2021-01-04"
+        "citations": 1220,
+        "datestamp": "2025-03-02"
       },
       "Wannier90": {
-        "citations": 361,
-        "datestamp": "2021-04-12"
+        "citations": 364,
+        "datestamp": "2025-03-02"
       },
       "YASARA": {
-        "citations": 379,
-        "datestamp": "2021-01-04"
+        "citations": 380,
+        "datestamp": "2025-03-02"
       },
       "Yambo": {
-        "citations": 99,
-        "datestamp": "2021-01-04"
+        "citations": 100,
+        "datestamp": "2025-03-02"
       },
       "deMon2k": {
-        "citations": 47,
-        "datestamp": "2024-03-06"
+        "citations": 46,
+        "datestamp": "2025-03-02"
       },
       "exciting": {
-        "citations": 42,
-        "datestamp": "2024-03-06"
-      },
-      "gSAFT": {
-        "citations": 13,
-        "datestamp": "2021-01-04"
+        "citations": 39,
+        "datestamp": "2025-03-02"
       },
       "xTB": {
-        "citations": 126,
-        "datestamp": "2021-01-17"
+        "citations": 123,
+        "datestamp": "2025-03-02"
       }
     },
     "year_high": 2019,


### PR DESCRIPTION
- Add 2024 data
- Update citation counts 2016-2023

Observations:
- citation counts for 2023 _decreased_ by ~10% vs data from 2024
  spot checks indicate that this may reflect a more accurate prediction of the total number of citations on the search result landing page
- with the new data, the 2022 citation counts appear like an outlier (too high). to be seen whether this is a real effect or due to a change in methodology on the google scholar side that has not yet propagated through all previous years